### PR TITLE
Update 02-learning-goals.adoc

### DIFF
--- a/docs/03-module-block-3/02-learning-goals.adoc
+++ b/docs/03-module-block-3/02-learning-goals.adoc
@@ -16,9 +16,6 @@ Die Teilnehmer:innen haben ein Verständnis für den Life-Cycle eines Machine-Le
 * Deployment
 * Maintenance
 
-[[LZ-3-2]]
-==== LZ 3-2: Vorgehensmodelle für die Softwareentwicklung von KI-Systemen kennen
-
 Die Teilnehmer:innen kennen typische Vorgehensmodelle für die Softwareentwicklung von KI-Systemen. Dies sind beispielsweise
 
 * CRISP-ML(Q)
@@ -26,38 +23,26 @@ Die Teilnehmer:innen kennen typische Vorgehensmodelle für die Softwareentwicklu
 * GenAI Life Cycle.
 
 [[LZ-3-3]]
-==== LZ 3-3: Arten von sowie Anforderungen an Daten und typische ML-Probleme kennen
+==== LZ 3-3: Datenarten und Anforderungen an Daten sowie typische ML-Problemstellungen und deren Anforderungen verstehen
 
-Die Teilnehmer:innen kennen verschiedene Arten von Daten und typische ML-Probleme sowie Anwendungsfälle für die Nutzung der Daten. Darüber hinaus haben
-die Teilnehmer:innen ein Verständnis für verschiedene Anforderungen an die Daten, z.{nbsp}B. Vorhandensein von korrekten Labels verschiedener Art.
-
-[[LZ-3-4]]
-==== LZ 3-4: Machine Learning Problemstellungen und deren Anforderungen verstehen
-
-Die Teilnehmer:innen verstehen die verschiedenen Machine Learning Problemstellungen wie beispielsweise
+Die Teilnehmer:innen kennen verschiedene Arten von Daten sowie typische ML-Probleme und Anwendungsfälle für die Nutzung der Daten aus den Bereichen:
 
 * Supervised Learning
 * Unsupervised Learning
 * Reinforcement Learning
 
-und wissen, welche Anforderungen diese haben.
+und verstehen, welche Anforderungen diese haben können, z.B.:
 
-[[LZ-3-5]]
-==== LZ 3-5: Input Daten für verschiedene KI-Algorithmen nutzen
+* Vorhandensein von korrekten Labels verschiedener Art
+* Datenumfang und -diversität
+* Zeitliche oder semantische Abhängigkeiten in Datenmerkmalen
+* Kodierung der Eingabedaten von ML-Modellen, z.B.:
+  * One-Hot-Encodings
+  * Label Encodings
+  * Embeddings
 
-Die Teilnehmer:innen wissen welche Daten für KI-Algorithmen benötigt werden und haben ein gutes Verständnis für die Notwendigkeit von Validierung und Kenntnis der typischen Datenaufteilung in Trainings-, Validierungs- und Testdaten. Außerdem haben die Teilnehmer:innen ein gutes Verständnis der Input-Daten, die für verschiedene KI-Algorithmen wie beispielsweise
+Insbesondere haben die Teilnehmer:innen ein gutes Verständnis für die Notwendigkeit von Validierung und Kenntnis der typischen Datenaufteilung in Trainings-, Validierungs- und Testdaten.
 
-* Neuronale Netze als numerische Vektoren und Matrizen bzw. Tensoren
-* One-Hot-Encodings
-* Embeddings
-
-benötigt werden.
-
-
-[[LZ-3-6]]
-==== LZ 3-6: Mit Herausforderungen wie Nicht-Determinismus, Datenqualität und Concept- und Modell-Drift umgehen
-
-Die Teilnehmer:innen verstehen, wie man mit Herausforderungen wie Nicht-Determinismus, Datenqualität und Concept- und Modell-Drift umgeht.
 
 [[LZ-3-7]]
 ==== LZ 3-7: Transfer-Learning bzw. Fine-Tuning kennen
@@ -66,7 +51,7 @@ Die Teilnehmer:innen kennen Transfer-Learning bzw. Fine-Tuning als Möglichkeit,
 
 
 [[LZ-3-8]]
-==== LZ 3-8: Design Patterns für KI-Systeme auswählen
+==== LZ 3-8: Geeignete Architektur- und Design-Patterns für KI-Systeme auswählen, gegeneinander abwägen und anhand von Qualitätsanforderungen begründen.
 
 Die Teilnehmer:innen wissen, welche Design Patterns für KI-Systeme existieren und wie man passende Patterns auswählt. Das betrifft die folgenden Design Patterns:
 
@@ -76,17 +61,6 @@ Die Teilnehmer:innen wissen, welche Design Patterns für KI-Systeme existieren u
 * Model Serving Patterns
 * Model Deployment Patterns
 
-[[LZ-3-9]]
-==== LZ 3-9: Aufgabe eines ML-Modells definieren
-
-Die Teilnehmer:innen wissen, wie man die Anwendungsfälle / Aufgaben eines ML-Modells definiert, wie beispielsweise die
-Klassifikation von Bildern oder die Erkennung von Betrug.
-
-
-[[LZ-3-10]]
-==== LZ 3-10: Eingaben und Ausgaben für das Funktionieren eines ML-Systems verstehen und spezifizieren
-
-Die Teilnehmer:innen verstehen, welche Eingaben und Ausgaben für das Funktionieren eines ML-Systems erforderlich sind und können diese spezifizieren.
 
 [[LZ-3-11]]
 ==== LZ 3-11: Metriken zur Messung der Performance von ML-Modellen kennen
@@ -100,12 +74,12 @@ Die Teilnehmer:innen kennen verschiedene Metriken zur Messung der Performance vo
 und wissen, wie man Bewertungskriterien zur Leistungsbeurteilung festlegt.
 
 [[LZ-3-12]]
-==== LZ 3-12: ML-Modelle in bestehende Systeme integrieren
+==== LZ 3-12: KI-Komponenten über geeignete Integrationsmuster, Schnittstellen und Entkopplungsmechanismen in bestehende Systeme und Domänenarchitekturen integrieren.
 
 Die Teilnehmer:innen verstehen, wie ML-Modelle in bestehende Systeme integriert werden können und kennen die Schnittstellen und Integrationspunkte.
 
 [[LZ-3-13]]
-==== LZ 3-13: Benutzeroberflächen für KI-Systeme gestalten
+==== LZ 3-13: Benutzerinteraktionen für KI-Systeme so gestalten, dass Unsicherheit, Erklärbarkeit, Freigaben und Human-in-the-Loop angemessen berücksichtigt werden.
 
 Die Teilnehmer:innen wissen, wie Benutzeroberflächen gestaltet werden sollten, um effektive Interaktionen mit dem ML-System zu ermöglichen und die Benutzererfahrung zu optimieren.
 
@@ -127,21 +101,15 @@ wie man KI-Systeme entwickelt, die mit steigenden Datenvolumen umgehen können, 
 Die Teilnehmer:innen haben ein Verständnis davon, was Robustheit in KI-Systemen bedeutet,
 und können Strategien zur Erhöhung der Robustheit in verschiedenen Anwendungskontexten anwenden.
 
-
 [[LZ-3-17]]
 ==== LZ 3-17: Zuverlässigkeit und Verfügbarkeit von KI-Systemen einordnen
 
 Die Teilnehmer:innen verstehen die Konzepte der Zuverlässigkeit und Verfügbarkeit und wissen, wie sie KI-Systeme bauen, die stabil und konstant verfügbar sind.
 
 [[LZ-3-18]]
-==== LZ 3-18: Reproduzierbarkeit und Prüfbarkeit von KI-Ergebnisse verstehen
+==== LZ 3-18: Maßnahmen für Reproduzierbarkeit, Auditierbarkeit und Nachvollziehbarkeit von Modellen, Datenständen, Prompts, Konfigurationen und Ergebnissen festlegen.
 
 Die Teilnehmer:innen wissen, wie wichtig es ist, dass KI-Ergebnisse reproduzierbar und prüfbar sind, und wissen, welche Methoden zur Sicherstellung dieser Eigenschaften eingesetzt werden können.
-
-[[LZ-3-19]]
-==== LZ 3-19: Anforderungen an Sicherheit, Datenschutz und Compliance kennen
-
-Die Teilnehmer:innen kennen die Anforderungen an Sicherheit, Datenschutz und Compliance und wissen, wie diese in KI-Systemen umgesetzt werden.
 
 
 [[LZ-3-20]]
@@ -150,16 +118,21 @@ Die Teilnehmer:innen kennen die Anforderungen an Sicherheit, Datenschutz und Com
 Die Teilnehmer:innen verstehen die Bedeutung von Erklärbarkeit und Interpretierbarkeit in KI-Systemen und wissen,
 wie man diese sicherstellen kann, um Vertrauen und Transparenz zu fördern.
 
-
-[[LZ-3-21]]
-==== LZ 3-21: Bias in Daten und Modellen erkennen
-
-Die Teilnehmer:innen wissen, wie Bias in Daten und Modellen erkannt und reduziert werden können, um Fairness und Gleichbehandlung in KI-Anwendungen sicherzustellen.
-
 [[LZ-3-22]]
 ==== LZ 3-22: Fehlertoleranz in KI-Systemen kennen
 
 Die Teilnehmer:innen kennen die Konzepte der Fehlertoleranz und können erläutern, wie KI-Systeme trotz Fehlern oder Störungen funktionsfähig bleiben.
+
+[[LZ-3-23]] 
+==== LZ 3-23: Architekturentscheidungen für KI-Systeme dokumentieren.
+
+Die Teilnehmer:innen wissen, wie man die Anwendungsfälle / Aufgaben eines ML-Modells definiert und dokumentiert, wie beispielsweise die Klassifikation von Bildern oder die Erkennung von Betrug, insbesondere Trade-offs zu:
+* RAG versus Fine-Tuning
+* SaaS versus Self-Hosting
+* Batch versus Realtime
+* Zentralem versus domänenspezifischem KI-Service.
+
+Die Teilnehmer:innen kennen 
 
 // end::DE[]
 
@@ -329,9 +302,5 @@ The participants know how bias in data and models can be recognized and reduced 
 ==== LG 3-22: Knowing fault tolerance in AI systems
 
 Participants are familiar with the concepts of fault tolerance and can explain how AI systems remain functional despite errors or malfunctions.
-
-
-
-
 
 // end::EN[]


### PR DESCRIPTION
    * LZ 3-1 und 3-2 zusammengefasst, da inhaltlich passend
    * LZ 3-3 mit LZ 3-4 und LZ 3-5 zusammengefasst
    * LZ 3-6 kann weggelassen werden, das LZ ist nicht konkret genug, LZ 5-8 ist redundant - das Thema passt in Kapitel 5 besser -> LZ 3-6 entfernt
    * LZ 3-9 mit neuem 3-23 zusammengefasst, da inhaltlich passend
    * LZ 3-10 entfernt, da redundant zu neuem LZ 3-3
    * LZ 3-19 entfernt, da redundant und bereits in Kapitel 2 behandelt
    * LZ 3-21 entfernt und mit ähnlichem LZ 2-11 kombiniert, Bias passt besser zu AI Safety, Ethik, Risiko und Daten-Governance in Modul 2 als zu Entwurf/Entwicklung in Modul 3