### PR TITLE
Update 02-learning-goals.adoc

### DIFF
--- a/docs/05-module-block-5/02-learning-goals.adoc
+++ b/docs/05-module-block-5/02-learning-goals.adoc
@@ -6,7 +6,7 @@
 [[LZ-5-1]]
 ==== LZ 5-1: (Hardware)-Anforderungen an Training und Inferenz kennen
 
-Die Teilnehmer:innen kennen unterschiedliche (Hardware)-Anforderungen für beispielsweise TPU, GPU oder CPU an Training und Inferenz.
+Die Teilnehmer:innen kennen unterschiedliche (Hardware)-Anforderungen für beispielsweise TPU, NPU, LPU, GPU oder CPU an Training und Inferenz.
 
 [[LZ-5-2]]
 ==== LZ 5-2: Trade-Offs verschiedener Modellarchitekturen bezüglich der Qualitätsmerkmale kennen
@@ -41,7 +41,7 @@ Die Teilnehmer:innen kennen den Begriff MLOps für die Automatisierung des Life-
 Die Teilnehmer:innen haben ein Verständnis vom Tracking im Modelltraining, Parametern, Metriken und Ergebnissen.
 
 [[LZ-5-7]]
-==== LZ 5-7: ML-Modelle und darauf aufbauenden KI-Systeme evaluieren
+==== LZ 5-7: Modellevaluation, Systemevaluation und fachliche Nutzenbewertung unterscheiden und geeignete Evaluationsansätze für KI-Systeme auswählen.
 
 Die Teilnehmer:innen überblicken Ansätze zur Evaluation von ML-Modellen und darauf aufbauenden KI-Systemen.
 
@@ -56,12 +56,9 @@ Die Teilnehmer:innen kennen verschiedene Arten von Drift, wie beispielsweise Dat
 Die Teilnehmer:innen haben ein Verständnis von CI/CD-Pipelines, Modellmanagement und Deployment-Strategien für KI-Modelle.
 
 [[LZ-5-10]]
-==== LZ 5-10: Plattformen für die Modellbereitstellung kennen
+==== LZ 5-10: [OPTIONAL] Plattformen für die Modellbereitstellung kennen
 
 Die Teilnehmer:innen kennen gängige Plattformen für die Modellbereitstellung, wie beispielsweise Huggingface Hub.
-
-[[LZ-5-11]]
-==== LZ 5-11: Werkzeuge für das Erstellen von POCs von KI-Systemen einordnen
 
 Die Teilnehmer:innen können gängige Werkzeuge für das Erstellen von POCs von KI-Systemen, wie beispielsweise Gradio, nennen und verstehen die konzeptionelle Funktionsweise.
 
@@ -89,20 +86,13 @@ Die Teilnehmer:innen kennen die Vor- und Nachteile von SaaS und Self-Hosting und
 
 Die Teilnehmer:innen überblicken bekannte SaaS-KI-Lösungen, wie beispielsweise Azure OpenAI Services.
 
-[[LZ-5-15]]
-==== LZ 5-15: Embedded Deployments von ML-Modellen kennen
-
-Die Teilnehmer:innen kennen verschiedene Möglichkeiten und Standards für Embedded Deployments von ML-Modellen.
 
 [[LZ-5-16]]
-==== LZ 5-16: Monitoring im Hinblick auf KI-spezifische Anforderungen verstehen
+==== LZ 5-16: Monitoring und Observability für KI-Systeme konzipieren, insbesondere für Drift, Qualitätsverlust, Kosten, Latenz, Sicherheitsereignisse und Governance-relevante Nachweise.
 
 Die Teilnehmer:innen verstehen die Notwendigkeit für Monitoring, auch im Hinblick auf KI-spezifische Anforderungen wie das Tracking von Drift.
 
 Die Teilnehmer:innen kennen relevante Metriken wie beispielsweise Accuracy, Precision, Recall, F1-Score, MAE, MSE, Perplexity, Latenz, Durchsatz und Ressourcenauslastung und verstehen, warum diese für das Monitoring relevant sind.
-
-[[LZ-5-17]]
-==== LZ 5-17: Beispiel-Werkzeuge für Monitoring überblicken
 
 Die Teilnehmer:innen kennen Beispiel-Werkzeuge für Monitoring. Dies betrifft sowohl allgemeine Werkzeuge, wie beispielsweise Prometheus & Grafana,
 als auch ML-spezifische wie beispielsweise MLflow.
@@ -114,7 +104,7 @@ Die Teilnehmer:innen verstehen den Nutzen von Nutzer-Feedback für das weitere M
 
 
 [[LZ-5-19]]
-==== LZ 5-19: Methoden zur Nutzung von Feedback für das Modell-Training kennen
+==== LZ 5-19: [OPTIONAL] Methoden zur Nutzung von Feedback für das Modell-Training kennen
 
 Die Teilnehmer:innen kennen verschiedene Methoden zur Nutzung von Feedback für das Modell-Training, wie beispielsweise RLHF, RLAIF und DPO.
 
@@ -124,12 +114,12 @@ Die Teilnehmer:innen kennen verschiedene Methoden zur Nutzung von Feedback für 
 Die Teilnehmer:innen erfahren anhand eines Praxisbeispiels, wie eine MLOps-Pipeline aussehen kann und welche Einsichten diese auf die Parameter, Metriken usw. bietet.
 
 [[LZ-5-21]]
-==== LZ 5-21: [OPTIONAL] Build vs. Buy Entscheidungen für MLOps Systeme/Komponenten treffen
+==== LZ 5-21: Build-vs.-Buy-Entscheidungen für MLOps- und KI-Plattform-Komponenten anhand von Qualitätsanforderungen, Kosten, Risiko, Compliance und Integrationsaufwand treffen.
 
 Die Teilnehmer:innen sind in der Lage, Build vs. Buy Entscheidungen für MLOps Systeme/Komponenten zu treffen.
 
 [[LZ-5-22]]
-==== LZ 5-22: [OPTIONAL] MLOps-Werkzeuge und End-to-End Plattformen kennen
+==== LZ 5-22: [OPTIONAL] Klassen von MLOps-Werkzeugen und Plattformen sowie wesentliche Auswahlkriterien für ihren Einsatz kennen.
 
 Die Teilnehmer:innen kennen bekannte MLOps-Werkzeuge und End-to-End Plattformen,wie beispielsweise:
 


### PR DESCRIPTION
    * LZ 5-1 bleibt und erweitert um NPUs und LPUs, da neue KI-Beschleuniger meist sehr interessant für Teilnehmer und hier viel Kosten-&Effizienzpotentiale zur Laufzeit liegen
    * LZ 5-10 und 5-11 zusammengefasst und [OPTIONAL] gekennzeichnet
    * LZ 5-15 entfernt, da redundant zu 3-8
    * LZ 5-16 und 5-17 zusammengefasst
    * LZ 5-19 als [OPTIONAL] gekennzeichnet, meist interessant für Teilnehmer für die systematische, iterative ML-Optimierung, aber nicht der zentralste Inhalt