### PR TITLE
RC Curriculum SWARC4AI v2.0

### DIFF
--- a/docs/01-module-block-1/02-learning-goals.adoc
+++ b/docs/01-module-block-1/02-learning-goals.adoc
@@ -71,73 +71,67 @@ Dieses Phänomen hilft zu verstehen, warum Unternehmen bei der Implementierung v
 // tag::EN[]
 
 [[LG-1-1]]
-==== LG 1-1: Classify artificial intelligence and machine learning, data science, deep learning, generative AI
+==== LG 1-1: Classify artificial intelligence and machine learning, data science, deep learning, and generative AI
 
-Participants will know how artificial intelligence is defined and how machine learning, data science, deep learning and generative AI are categorized within it.
+Participants know how artificial intelligence is defined and how machine learning, data science, deep learning, and generative AI fit within it.
 
 [[LG-1-2]]
-==== LG 1-2: Specify typical general use cases for AI
+==== LG 1-2: Identify, classify, prioritize, and evaluate AI use cases from a business perspective
 
-Participants will know how to specify typical general use cases for AI. This includes use cases for e.g. image recognition & generation, language processing, prediction, personalization and anomaly detection.
+Participants can identify and describe typical AI use cases from a business perspective. They can evaluate their suitability based on business goals, data availability and quality, technical feasibility, expected benefits, risks, integration effort, and impact on the software architecture, and can establish a well-founded prioritization.
+
+Typical use cases include image recognition and image generation, natural language processing, predictive models, personalization, anomaly detection, chatbots, recommender systems, and intelligent assistance systems.
 
 [[LG-1-3]]
-==== LG 1-3: Know possible applications in different industries and end-user applications
+==== LG 1-3: Classify the strengths, limitations, and typical risks of AI
 
-Participants will be familiar with the possible applications in various industries, e.g. marketing, medicine, robotics and content creation. They will also gain an overview of the possible uses of AI in end-user applications. These include, for example, voice assistants (chatbots) and recommendation systems (recommender engines).
+Participants can classify the strengths and limitations of AI technologies in different application contexts and explain why the suitability of AI depends heavily on the task at hand.
+
+They can identify typical technical and societal risks, such as
+
+* hallucinations,
+* bias,
+* unfairness,
+* deepfakes,
+* AI-assisted cyberattacks,
+* safety risks in critical systems,
+* social manipulation,
+* infringements of intellectual property rights.
+
+[OPTIONAL]
+Participants are familiar with the “Jagged Technological Frontier” in relation to the task-specific suitability of AI.
 
 [[LG-1-4]]
-==== LG 1-4: Identify risks in the application of AI
-
-Participants can identify risks that arise when using AI. These can be the following risks, for example:
-
-- Hallucinations
-- Bias
-- (un)fairness
-- societal risks such as deepfakes, AI-enabled cyberattacks, safety risks in critical systems, social manipulation, intellectual property issues, etc.
-
-
-[[LG-1-5]]
-==== LG 1-5: Understanding differences to traditional software
+==== LG 1-4: Understand and explain the differences between AI systems and traditional software and decide on the appropriate type of solution
 
 Participants understand the differences between AI systems and traditional software:
 
-- Data-driven (with ML) - data-centric instead of code-centric development
-- Probabilistic results (non-deterministic behavior)
-- Statistical validation
-- Experimental design: Support for rapid iteration and testing of models.
-- Model complexity and interpretability: ML models, especially deep learning models, can be extremely complex. The "black box" character makes them difficult to interpret and explain.
-- Debugging and testing are more complex due to non-determinism.
-- Model decay: Continuous monitoring and retraining are necessary to maintain model performance.
-- AI-specific regulation of industries and at EU level must be taken into account.
-- Interoperability: Seamless integration into existing systems and technology stacks.
+* Data-driven (for ML) – data-centric rather than code-centric development
+* Probabilistic results (non-deterministic behavior)
+* Statistical validation
+* Experimental design: support for rapid iteration and model testing
+* Model complexity and interpretability: ML models, particularly deep learning models, can be extremely complex. Their “black-box” nature makes interpretation and explanation more difficult.
+* Debugging and testing are more complex due to non-determinism.
+* Model decay: continuous monitoring and retraining are necessary to maintain model performance.
+* AI-specific regulations at industry and EU level must be taken into account.
+* Interoperability: seamless integration into existing systems and technology stacks.
 
+Participants can decide and explain whether and why a problem should be solved using AI or traditional software development.
+
+[[LG-1-5]]
+==== LG 1-5: Know roles, their responsibilities, and how they collaborate in the context of AI
+
+Participants know typical roles and their responsibilities in these contexts. In particular, these roles include:
+
+Data Scientist, Data Analyst, Data Engineer, Machine Learning Engineer, MLOps Engineer, AI Architect,
+Data Architect, Business Intelligence (BI) Developer, Data Governance Specialist, and ML Researcher.
+
+Participants also know how these roles can collaborate within a team (team topologies for ML teams).
 
 [[LG-1-6]]
-==== LG 1-6: Decide on solutions to problems using AI or classic software development
+==== LG 1-6 [OPTIONAL]: Know the concept of the Productivity J-Curve as a framework for introducing AI in organizations
 
-Participants can decide and explain whether and why a problem should be solved using either AI or classic software development.
-
-[[LG-1-7]]
-==== LG 1-7: Know roles and their tasks as well as their cooperation in the context of AI
-
-The participants know typical roles and their tasks in these contexts. The roles include in particular
-
-Data Scientist, Data Analyst, Data Engineer, Machine Learning Engineer, MLOps Engineer, AI Architect, Data Architect, Business Intelligence (BI) Developer, Data Governance Specialist and ML Researcher.
-
-[[LG-1-8]]
-==== LG 1-8: Identify and prioritize AI use cases
-
-Participants will be able to identify and prioritize AI use cases.
-
-[[LG-1-9]]
-==== LG 1-9: Know the strengths and limitations of AI
-Participants understand the strengths and limitations of AI and are familiar with the so-called "Jagged Technological Frontier".
-
-[[LG-1-10]]
-==== LG 1-10: Know the concept of the Productivity J-Curve in conjunction with AI technology
-
-This phenomenon helps to understand why companies can initially experience a drop in productivity when implementing AI, but this can be followed by productivity gains as it develops further.
-
+This phenomenon helps explain why organizations may initially experience a decline in productivity when implementing AI, followed by productivity gains as implementation progresses.
 
 
 // end::EN[]

--- a/docs/01-module-block-1/02-learning-goals.adoc
+++ b/docs/01-module-block-1/02-learning-goals.adoc
@@ -8,11 +8,11 @@
 Die Teilnehmer:innen wissen, wie man Künstliche Intelligenz definiert und wie Machine Learning, Data Science, Deep Learning, Generative KI darin eingeordnet werden.
 
 [[LZ-1-2]]
-==== LZ 1-2: Typische KI-Anwendungsfälle einordnen, fachlich beschreiben und hinsichtlich Nutzen, Risiken und Architekturauswirkungen bewerten.
+==== LZ 1-2: KI-Anwendungsfälle identifizieren, fachlich einordnen, priorisieren und bewerten
 
-Die Teilnehmer:innen kennen typische allgemeine Anwendungsfälle und Einsatzmöglichkeiten von KI in verschiedenen Branchen sowie in Endnutzeranwendungen. Dazu zählen z. B. Bilderkennung und Bildgenerierung, Sprachverarbeitung, Vorhersagemodelle, Personalisierung und Anomalieerkennung sowie Anwendungen wie Chatbots, Empfehlungssysteme und intelligente Assistenzsysteme in Bereichen wie Marketing, Medizin, Robotik und Content-Creation.
+Die Teilnehmer:innen können typische KI-Anwendungsfälle identifizieren und fachlich beschreiben. Sie können deren Eignung anhand fachlicher Ziele, Datenverfügbarkeit und -qualität, technischer Umsetzbarkeit, erwartbarem Mehrwert, Risiken, Integrationsaufwand und Auswirkungen auf die Softwarearchitektur bewerten und eine begründete Priorisierung vornehmen.
 
-Die Teilnehmer:innen sind in der Lage, diese Anwendungsfälle fachlich einzuordnen sowie hinsichtlich Nutzen, Risiken und möglicher Auswirkungen auf Softwarearchitekturen zu bewerten.
+Typische Anwendungsfälle umfassen beispielsweise Bilderkennung und Bildgenerierung, Sprachverarbeitung, Vorhersagemodelle, Personalisierung, Anomalieerkennung, Chatbots, Empfehlungssysteme und intelligente Assistenzsysteme.
 
 [[LZ-1-4]]
 ==== LZ 1-4: Risiken bei der Anwendung von KI identifizieren
@@ -56,11 +56,6 @@ Data Architect, Business Intelligence (BI) Developer, Data Governance Specialist
 
 Die Teilnehmer:innen wissen darüber hinaus, wie diese Rollen im Team zusammenarbeiten könnten (Team Topologies für ML-Teams).
 
-
-[[LZ-1-8]]
-==== LZ 1-8: KI-Anwendungsfälle anhand fachlicher Ziele, Datenverfügbarkeit, Umsetzbarkeit, Risiken, Integrationsaufwand und erwartbarem Mehrwert identifizieren, priorisieren und begründen.
-
-Die Teilnehmer:innen können KI Anwendungsfälle identifizieren und priorisieren.
 
 [[LZ-1-9]]
 ==== LZ 1-9: Stärken und Grenzen von KI kennen

--- a/docs/01-module-block-1/02-learning-goals.adoc
+++ b/docs/01-module-block-1/02-learning-goals.adoc
@@ -14,8 +14,8 @@ Die Teilnehmer:innen können typische KI-Anwendungsfälle identifizieren und fac
 
 Typische Anwendungsfälle umfassen beispielsweise Bilderkennung und Bildgenerierung, Sprachverarbeitung, Vorhersagemodelle, Personalisierung, Anomalieerkennung, Chatbots, Empfehlungssysteme und intelligente Assistenzsysteme.
 
-[[LZ-1-4]]
-==== LZ 1-4: Stärken, Grenzen und typische Risiken von KI einordnen
+[[LZ-1-3]]
+==== LZ 1-3: Stärken, Grenzen und typische Risiken von KI einordnen
 
 Die Teilnehmer:innen können Stärken und Grenzen von KI-Technologien in unterschiedlichen Anwendungskontexten einordnen und erklären, warum die Eignung von KI stark von der jeweiligen Aufgabe abhängt.
 
@@ -32,8 +32,8 @@ Sie können typische technische und gesellschaftliche Risiken identifizieren, be
 [OPTIONAL]
 Die Teilnehmer:innen kennen die „Jagged Technological Frontier“ bzgl. der aufgabebezogenen Eignung von KI.
 
-[[LZ-1-5]]
-==== LZ 1-5: Unterschiede zwischen KI-Systemen und traditioneller Software verstehen, erklären und die geeignete Lösungsart entscheiden
+[[LZ-1-4]]
+==== LZ 1-4: Unterschiede zwischen KI-Systemen und traditioneller Software verstehen, erklären und die geeignete Lösungsart entscheiden
 
 Die Teilnehmer:innen verstehen die Unterschiede von KI-Systemen zu traditioneller Software:
 
@@ -49,8 +49,8 @@ Die Teilnehmer:innen verstehen die Unterschiede von KI-Systemen zu traditionelle
 
 Teilnehmer:innen können entscheiden und erklären, ob und warum ein Problem mittels KI oder klassischer SW-Entwicklung zu lösen ist.
 
-[[LZ-1-7]]
-==== LZ 1-7: Rollen und deren Aufgaben sowie ihre Zusammenarbeit im Kontext von KI kennen
+[[LZ-1-5]]
+==== LZ 1-5: Rollen und deren Aufgaben sowie ihre Zusammenarbeit im Kontext von KI kennen
 
 Die Teilnehmer:innen kennen typische Rollen und deren Aufgaben in diesen Kontexten. Die Rollen umfassen insbesondere:
 
@@ -60,8 +60,8 @@ Data Architect, Business Intelligence (BI) Developer, Data Governance Specialist
 Die Teilnehmer:innen wissen darüber hinaus, wie diese Rollen im Team zusammenarbeiten könnten (Team Topologies für ML-Teams).
 
 
-[[LZ-1-10]]
-==== LZ 1-10 [OPTIONAL]: Das Konzept der Productivity J-Curve als Einordnungsrahmen für die Einführung von KI in Organisationen kennen.
+[[LZ-1-6]]
+==== LZ 1-6 [OPTIONAL]: Das Konzept der Productivity J-Curve als Einordnungsrahmen für die Einführung von KI in Organisationen kennen.
 
 Dieses Phänomen hilft zu verstehen, warum Unternehmen bei der Implementierung von KI zunächst einen Produktivitätsrückgang verzeichnen können, dem bei der weiteren Entwicklung aber Produktivitätsgewinne folgen können.
 

--- a/docs/01-module-block-1/02-learning-goals.adoc
+++ b/docs/01-module-block-1/02-learning-goals.adoc
@@ -8,15 +8,11 @@
 Die Teilnehmer:innen wissen, wie man Künstliche Intelligenz definiert und wie Machine Learning, Data Science, Deep Learning, Generative KI darin eingeordnet werden.
 
 [[LZ-1-2]]
-==== LZ 1-2: Typische allgemeine Anwendungsfälle für KI spezifizieren
+==== LZ 1-2: Typische KI-Anwendungsfälle einordnen, fachlich beschreiben und hinsichtlich Nutzen, Risiken und Architekturauswirkungen bewerten.
 
-Die Teilnehmer:innen wissen, wie typische allgemeine Anwendungsfälle für KI spezifiziert werden können. Dies umfasst Anwendungsfälle für z.{nbsp}B. Bilderkennung & -erzeugung, Sprachverarbeitung, Vorhersagen, Personalisierung und Anomalieerkennung.
+Die Teilnehmer:innen kennen typische allgemeine Anwendungsfälle und Einsatzmöglichkeiten von KI in verschiedenen Branchen sowie in Endnutzeranwendungen. Dazu zählen z. B. Bilderkennung und Bildgenerierung, Sprachverarbeitung, Vorhersagemodelle, Personalisierung und Anomalieerkennung sowie Anwendungen wie Chatbots, Empfehlungssysteme und intelligente Assistenzsysteme in Bereichen wie Marketing, Medizin, Robotik und Content-Creation.
 
-[[LZ-1-3]]
-==== LZ 1-3: Einsatzmöglichkeiten in verschiedenen Branchen und Endnutzeranwendungen kennen
-
-Die Teilnehmer:innen kennen die möglichen Einsatzmöglichkeiten in verschiedenen Branchen, z.{nbsp}B. Marketing, Medizin, Robotik und Content-Creation. Darüber hinaus überblicken sie die Einsatzmöglichkeiten in Endnutzeranwendungen von KI. Darunter fallen z.{nbsp}B. Sprachassistenten (Chatbots) und Empfehlungssysteme (Recommender Engine).
-
+Die Teilnehmer:innen sind in der Lage, diese Anwendungsfälle fachlich einzuordnen sowie hinsichtlich Nutzen, Risiken und möglicher Auswirkungen auf Softwarearchitekturen zu bewerten.
 
 [[LZ-1-4]]
 ==== LZ 1-4: Risiken bei der Anwendung von KI identifizieren
@@ -62,7 +58,7 @@ Die Teilnehmer:innen wissen darüber hinaus, wie diese Rollen im Team zusammenar
 
 
 [[LZ-1-8]]
-==== LZ 1-8: KI Anwendungsfällen identifizieren und priorisieren
+==== LZ 1-8: KI-Anwendungsfälle anhand fachlicher Ziele, Datenverfügbarkeit, Umsetzbarkeit, Risiken, Integrationsaufwand und erwartbarem Mehrwert identifizieren, priorisieren und begründen.
 
 Die Teilnehmer:innen können KI Anwendungsfälle identifizieren und priorisieren.
 
@@ -72,7 +68,7 @@ Die Teilnehmer:innen können KI Anwendungsfälle identifizieren und priorisieren
 Die Teilnehmer:innen verstehen die Stärken und die Grenzen von KI und kennen die sog. "Jagged Technological Frontier".
 
 [[LZ-1-10]]
-==== LZ 1-10: Konzept der Productivity J-Curve in Verbindung mit KI-Technologie kennen
+==== LZ 1-10 [OPTIONAL]: Das Konzept der Productivity J-Curve als Einordnungsrahmen für die Einführung von KI in Organisationen kennen.
 
 Dieses Phänomen hilft zu verstehen, warum Unternehmen bei der Implementierung von KI zunächst einen Produktivitätsrückgang verzeichnen können, dem bei der weiteren Entwicklung aber Produktivitätsgewinne folgen können.
 

--- a/docs/01-module-block-1/02-learning-goals.adoc
+++ b/docs/01-module-block-1/02-learning-goals.adoc
@@ -15,16 +15,22 @@ Die Teilnehmer:innen können typische KI-Anwendungsfälle identifizieren und fac
 Typische Anwendungsfälle umfassen beispielsweise Bilderkennung und Bildgenerierung, Sprachverarbeitung, Vorhersagemodelle, Personalisierung, Anomalieerkennung, Chatbots, Empfehlungssysteme und intelligente Assistenzsysteme.
 
 [[LZ-1-4]]
-==== LZ 1-4: Risiken bei der Anwendung von KI identifizieren
+==== LZ 1-4: Stärken, Grenzen und typische Risiken von KI einordnen
 
-Die Teilnehmer:innen können Risiken, die bei der Anwendung von KI auftreten, identifizieren. Das können beispielsweise folgende Risiken sein:
+Die Teilnehmer:innen können Stärken und Grenzen von KI-Technologien in unterschiedlichen Anwendungskontexten einordnen und erklären, warum die Eignung von KI stark von der jeweiligen Aufgabe abhängt.
 
-* Halluzinationen
-* Bias
-* (un-)Fairness
-* gesellschaftlichen Risiken wie Deepfakes, AI-enabled Cyberattacks, Safety Risks in Critical Systems, Social Manipulation, Intellectual Property Issues usw.
+Sie können typische technische und gesellschaftliche Risiken identifizieren, beispielsweise
+* Halluzinationen,
+* Bias,
+* Unfairness
+* Deepfakes,
+* KI-gestützte Cyberangriffe,
+* Sicherheitsrisiken in kritischen Systemen,
+* Soziale Manipulation,
+* Verletzungen geistiger Eigentumsrechte
 
-
+[OPTIONAL]
+Die Teilnehmer:innen kennen die „Jagged Technological Frontier“ bzgl. der aufgabebezogenen Eignung von KI.
 
 [[LZ-1-5]]
 ==== LZ 1-5: Unterschiede zu traditioneller Software verstehen
@@ -56,11 +62,6 @@ Data Architect, Business Intelligence (BI) Developer, Data Governance Specialist
 
 Die Teilnehmer:innen wissen darüber hinaus, wie diese Rollen im Team zusammenarbeiten könnten (Team Topologies für ML-Teams).
 
-
-[[LZ-1-9]]
-==== LZ 1-9: Stärken und Grenzen von KI kennen
-
-Die Teilnehmer:innen verstehen die Stärken und die Grenzen von KI und kennen die sog. "Jagged Technological Frontier".
 
 [[LZ-1-10]]
 ==== LZ 1-10 [OPTIONAL]: Das Konzept der Productivity J-Curve als Einordnungsrahmen für die Einführung von KI in Organisationen kennen.

--- a/docs/01-module-block-1/02-learning-goals.adoc
+++ b/docs/01-module-block-1/02-learning-goals.adoc
@@ -33,7 +33,7 @@ Sie können typische technische und gesellschaftliche Risiken identifizieren, be
 Die Teilnehmer:innen kennen die „Jagged Technological Frontier“ bzgl. der aufgabebezogenen Eignung von KI.
 
 [[LZ-1-5]]
-==== LZ 1-5: Unterschiede zu traditioneller Software verstehen
+==== LZ 1-5: Unterschiede zwischen KI-Systemen und traditioneller Software verstehen, erklären und die geeignete Lösungsart entscheiden
 
 Die Teilnehmer:innen verstehen die Unterschiede von KI-Systemen zu traditioneller Software:
 
@@ -46,9 +46,6 @@ Die Teilnehmer:innen verstehen die Unterschiede von KI-Systemen zu traditionelle
 * Model Decay: Continuous monitoring und Retraining sind notwendig, um die Leistung der Modelle aufrechtzuerhalten.
 * KI-spezifische Regulatorik von Branchen und auf EU-Ebene müssen berücksichtigt werden.
 * Interoperabilität: Nahtlose Integration in bestehende Systeme und Technologiestacks.
-
-[[LZ-1-6]]
-==== LZ 1-6: Lösung von Problemen mittels KI oder klassischer SW-Entwicklung entscheiden
 
 Teilnehmer:innen können entscheiden und erklären, ob und warum ein Problem mittels KI oder klassischer SW-Entwicklung zu lösen ist.
 

--- a/docs/01-module-block-1/references.adoc
+++ b/docs/01-module-block-1/references.adoc
@@ -1,8 +1,8 @@
 === {references}
 
-<<roser>>, <<brynjolfsson>>, <<burkov>>, <<geron>>, <<kelleher>>, <<vaughan>>,
-<<bahree>>, <<harvard>>, <<dellacqua>>, <<visenger-one>>,
-<<agrawal>>, <<tan>>, <<chong>>, <<hall>>, <<huyen>>, <<wang>>
+<<agrawal>>, <<bahree>>, <<brynjolfsson>>, <<burkov>>, <<chong>>,
+<<dellacqua>>, <<geron>>, <<gharbi>>, <<hall>>, <<harvard>>, <<huyen>>,
+<<kelleher>>, <<roser>>, <<tan>>, <<vaughan>>, <<visenger-one>>, <<wang>>
 
 // tag::DE[]
 // end::DE[]

--- a/docs/02-module-block-2/02-learning-goals.adoc
+++ b/docs/02-module-block-2/02-learning-goals.adoc
@@ -9,7 +9,7 @@
 Die Teilnehmer:innen kennen die Datenschutzgesetze wie die DSGVO und wissen, wie diese die Sammlung, Verarbeitung und Speicherung von Daten durch KI-Systeme beeinflussen.
 
 [[LZ-2-2]]
-==== LZ 2-2: Ziele und Regelungen des EU AI Act sowie deren Einfluss auf den Entwicklungsprozess und die Architektur verstehen
+==== LZ 2-2: Die Anforderungen des EU AI Act analysieren und daraus architekturrelevante Maßnahmen für Datenflüsse, Logging, technische Dokumentation, Human Oversight, Robustheit und Deployment ableiten.
 
 Die Teilnehmer:innen verstehen die Ziele und Regelungen des EU AI Act und wissen welchen Einfluss dies auf die Entwicklung und den Einsatz von KI-Systemen hat. Außerdem verstehen sie die Anforderungen des EU AI Act (Trustworthy AI) und welchen Einfluss diese Anforderungen auf den Entwicklungsprozess und die Architektur
 des Softwaresystems haben. Insbesondere kennen sie den Einfluss auf einige der folgenden Aspekte:
@@ -44,13 +44,13 @@ und der Modellparameter. Darüber hinaus kennen sie verschiedene Arten von Lizen
 
 
 [[LZ-2-6]]
-==== LZ 2-6: Strategien für die Einhaltung des EU AI Acts und mögliche Herausforderungen verstehen
+==== LZ 2-6: Strategien zur Einhaltung regulatorischer Anforderungen definieren und geeignete Nachweis- und Dokumentationsartefakte für Modelle, Datensätze und Betriebsprozesse festlegen.
 
 Die Teilnehmer:innen verstehen die Grundaussagen des EU AI Acts (insbesondere Transparenzpflichten) und kennen Strategien
 für deren Einhaltung sowie mögliche Herausforderungen dabei.
 
 [[LZ-2-7]]
-==== LZ 2-7: Modelle und Datensätze für die Nachvollziehbarkeit und Transparenz dokumentieren
+==== LZ 2-7: Dokumentationsartefakte für Modelle, Datensätze, Prompts, Evaluationsverfahren und Betriebsprozesse auswählen und deren Beitrag zu Nachvollziehbarkeit, Transparenz und Auditierbarkeit erklären.
 
 Die Teilnehmer:innen wissen, wie man Modelle und Datensätze effektiv dokumentiert, um Nachvollziehbarkeit und Transparenz zu gewährleisten.
 
@@ -79,7 +79,7 @@ Die Teilnehmer:innen wissen, wie Strategien zur KI-Risikominimierung entwickelt 
 
 
 [[LZ-2-10]]
-==== LZ 2-10: Möglichkeiten zur Absicherung gegen Angriffe (AI Security) anwenden
+==== LZ 2-10: Sicherheitsmaßnahmen gegen Angriffe auf KI-Systeme auswählen und in Architektur, Schnittstellen, Betriebsmodell und Schutzmechanismen integrieren.
 
 Die Teilnehmer:innen kennen verschiedene Möglichkeiten zur Absicherung gegen Angriffe (AI Security) und insbesondere kennen sie Möglichkeiten
 zur Integration von Sicherheitsstandards in die Architektur und können diese beim Entwurf berücksichtigen.
@@ -103,7 +103,7 @@ Die Teilnehmer:innen wissen um die Probleme hinsichtlich Ethik, die KI-Systeme m
 Die Teilnehmer:innen überblicken wichtige Ethik-Leitlinien wie die „EU-Ethik-Leitlinien für vertrauenswürdige KI“ sowie die „Google AI Ethics Guidelines“.
 
 [[LZ-2-14]]
-==== LZ 2-14: Kernprinzipien zu AI Governance und Responsible AI für Unternehmen kennen
+==== LZ 2-14: Prinzipien von AI Governance und Responsible AI in Organisations-, Entwicklungs- und Architekturentscheidungen übersetzen.
 
 Die Teilnehmer:innen kennen die wichtigsten Dokumente zu AI Governance, um die Kernprinzipien zu AI Governance und Responsible AI für das Unternehmen auszuarbeiten. Dies betrifft
 insbesondere die folgenden Dokumente:

--- a/docs/02-module-block-2/02-learning-goals.adoc
+++ b/docs/02-module-block-2/02-learning-goals.adoc
@@ -46,13 +46,12 @@ und der Modellparameter. Darüber hinaus kennen sie verschiedene Arten von Lizen
 [[LZ-2-6]]
 ==== LZ 2-6: Strategien zur Einhaltung regulatorischer Anforderungen definieren und geeignete Nachweis- und Dokumentationsartefakte für Modelle, Datensätze und Betriebsprozesse festlegen.
 
-Die Teilnehmer:innen verstehen die Grundaussagen des EU AI Acts (insbesondere Transparenzpflichten) und kennen Strategien
-für deren Einhaltung sowie mögliche Herausforderungen dabei.
+Die Teilnehmer:innen verstehen die Grundaussagen des EU AI Acts (insbesondere Transparenzpflichten) und kennen Strategien für deren Einhaltung sowie mögliche Herausforderungen dabei.
 
-[[LZ-2-7]]
-==== LZ 2-7: Dokumentationsartefakte für Modelle, Datensätze, Prompts, Evaluationsverfahren und Betriebsprozesse auswählen und deren Beitrag zu Nachvollziehbarkeit, Transparenz und Auditierbarkeit erklären.
+Sie können insbesondere Dokumentationsartefakte für Modelle, Datensätze, Prompts, Evaluationsverfahren, Änderungen und Betriebsprozesse auswählen und erklären, wie diese Nachvollziehbarkeit, Transparenz und Auditierbarkeit unterstützen.
 
-Die Teilnehmer:innen wissen, wie man Modelle und Datensätze effektiv dokumentiert, um Nachvollziehbarkeit und Transparenz zu gewährleisten.
+[OPTIONAL]
+Die Teilnehmer:innen können Regulatory Sandboxes als Instrument zur kontrollierten Erprobung innovativer KI-Systeme einordnen und deren Möglichkeiten, Grenzen und Konsequenzen bei Nichteinhaltung des EU AI Acts erläutern.
 
 
 [[LZ-2-8]]
@@ -64,7 +63,6 @@ Die Teilnehmer:innen kennen mögliche Fallstricke hinsichtlich Security sowie ty
 * Adversarial Attacks
 * Data Poisoning
 * Model Inversion & Extraction.
-
 
 
 [[LZ-2-9]]
@@ -109,12 +107,6 @@ Optional kennen die Teilnehmer:innen die wichtige Dokumente und Frameworks zu AI
 * OECD AI Principles, https://oecd.ai/en/ai-principles
 * The Asilomar AI Principles, https://futureoflife.org/open-letter/ai-principles/
 * The IEEE Ethically Aligned Design framework, https://standards.ieee.org/wp-content/uploads/import/documents/other/ead_v2.pdf
-
-[[LZ-2-14]]
-==== LZ 2-14: Einblick in die Einrichtung von "Regulatory Sandboxes" bekommen
-
-Die Teilnehmer:innen erhalten einen Einblick in die Einrichtung von "Regulatory Sandboxes" zur Förderung von Innovationen und
-in die möglichen rechtlichen Konsequenzen bei Nichteinhaltung der Vorschriften des AI-Acts.
 
 
 // end::DE[]

--- a/docs/02-module-block-2/02-learning-goals.adoc
+++ b/docs/02-module-block-2/02-learning-goals.adoc
@@ -100,125 +100,90 @@ Optional kennen die Teilnehmer:innen die wichtige Dokumente und Frameworks zu AI
 
 // tag::EN[]
 [[LG-2-1]]
-==== LG 2-1: Know the influence of data protection laws on the implementation and use of AI
+==== LG 2-1: Know how data protection laws affect the implementation and use of AI
 
-Participants are familiar with data protection laws such as the GDPR and know how they affect the collection, processing and storage of data by AI systems.
+Participants are familiar with data protection laws such as the GDPR and know how they affect the collection, processing, and storage of data by AI systems.
 
 [[LG-2-2]]
-==== LG 2-2: Understand the objectives and regulations of the EU AI Act and their impact on the development process and architecture
+==== LG 2-2: Analyze the requirements of the EU AI Act and derive architecture-relevant measures for data flows, logging, technical documentation, human oversight, robustness, and deployment
 
-The participants understand the objectives and regulations of the EU AI Act and know what influence this has on the development and use of AI systems. They also understand the requirements of the EU AI Act (Trustworthy AI) and what influence these requirements have on the development process and the architecture of the software system. In particular, they know the influence on some of the following aspects:
+Participants understand the objectives and provisions of the EU AI Act and know how they affect the development and use of AI systems. They also understand the EU AI Act requirements for trustworthy AI and how these requirements affect the development process and the architecture of the software system. In particular, they are familiar with the impact on some of the following aspects:
 
-- Risk management system (risk minimization)
-- Data quality and data governance (quality management system)
-- Creation and maintenance of comprehensive technical documentation for the AI system
-- Automatic recording/logging of events in the AI system.
-- Provision of clear and understandable information for users
-- Implementation of measures for human supervision
-- Ensuring an appropriate level of accuracy and robustness
-- Implementation of cyber security measures
+* Risk management system (risk mitigation)
+* Data quality and data governance (quality management system)
+* Creation and maintenance of comprehensive technical documentation for the AI system
+* Automatic recording/logging of events in the AI system
+* Provision of clear and comprehensible information to users
+* Implementation of human oversight measures
+* Assurance of an appropriate level of accuracy and robustness
+* Implementation of cybersecurity measures
 
 
 [[LG-2-3]]
-==== LG 2-3: Perform classification of AI systems according to the EU AI Act risk level
+==== LG 2-3: Classify AI systems according to the EU AI Act risk levels
 
-The participants know the classification of AI systems according to the EU AI Act risk levels (prohibited, high-risk, limited-risk, low-risk) and know which regulatory requirements apply in each case.
+Participants know how AI systems are classified according to the EU AI Act risk levels (prohibited, high risk, limited risk, and low risk) and which regulatory requirements apply in each case.
 
 
 [[LG-2-4]]
-==== LG 2-4: Classify copyright issues of AI-generated content
+==== LG 2-4: Evaluate copyright, degrees of openness, and licensing terms for AI models and AI-generated content
 
-The participants understand the copyright issues for AI-generated content, know the effects on certain software license models and can devise potential solutions for these issues.
+Participants can classify copyright issues relating to training data and AI-generated content and explain their impact on the development, provision, and use of AI systems.
+
+They can distinguish different degrees of openness of ML models, for example with regard to training data, source code, model architecture, and model parameters, and evaluate licensing terms and the resulting restrictions on an AI system.
 
 
 [[LG-2-5]]
-==== LG 2-5: Overview of types and degrees of openness and types of licenses of free ML models
+==== LG 2-5: Define strategies for complying with regulatory requirements and specify suitable evidence and documentation artifacts for models, datasets, and operational processes
 
-The participants gain an overview of different types and degrees of openness of free ML models. This concerns, for example, the disclosure of data and model parameters. In addition, they know different types of licenses of free ML models and their impact on the AI system.
+Participants understand the fundamental provisions of the EU AI Act, particularly its transparency obligations, and know strategies for complying with them as well as potential challenges.
+
+In particular, they can select documentation artifacts for models, datasets, prompts, evaluation procedures, changes, and operational processes, and explain how these support traceability, transparency, and auditability.
+
+[OPTIONAL]
+Participants can classify regulatory sandboxes as an instrument for the controlled testing of innovative AI systems and explain their opportunities, limitations, and the consequences of non-compliance with the EU AI Act.
 
 
 [[LG-2-6]]
-==== LG 2-6: Understand strategies for compliance with the EU AI Act and potential challenges
+==== LG 2-6: Know security pitfalls and types of attacks on ML models and select suitable security measures against attacks on AI systems
 
-The participants understand the basic statements of the EU AI Act (in particular transparency obligations) and know strategies for compliance and possible challenges.
+Participants know potential security pitfalls and typical types of attacks on ML models. These include, for example:
+
+* LLM jailbreaks through prompt engineering
+* Adversarial attacks
+* Data poisoning
+* Model inversion and extraction
+
+Participants know security measures for protecting against attacks (AI security), particularly ways to integrate security standards and safeguards into the architecture, interfaces, and operating model.
 
 
 [[LG-2-7]]
-==== LG 2-7: Document models and data sets for traceability and transparency
+==== LG 2-7: Know and apply strategies for AI risk mitigation
 
-Participants know how to effectively document models and data sets to ensure traceability and transparency.
+Participants know how strategies for AI risk mitigation can be developed and applied. In particular, they know the following strategies:
+
+* Strengthening robustness through extensive testing
+* Fault-tolerant AI systems
+* Transparent development
+* Explainable AI (XAI)
 
 
 [[LG-2-8]]
-==== LG 2-8: Know security pitfalls and types of attack on ML models
+==== LG 2-8: Understand the fundamental issues and facets of AI safety
 
-Participants will be familiar with possible security pitfalls and typical types of attack on ML models. This applies, for example:
+Participants understand the fundamental issues of AI safety and are familiar with its various facets. In particular, they know specific problems such as “AI model risks by poisoning” and bias.
 
-- LLM jailbreaks through prompt engineering
-- Adversarial Attacks
-- Data Poisoning
-- Model Inversion & Extraction.
-
-
+Participants know how bias in data and models can be detected and reduced to ensure fairness and equal treatment in AI applications.
 
 [[LG-2-9]]
-==== LG 2-9: Know and apply strategies for AI risk minimization
+==== LG 2-9: Translate ethical guidelines and AI governance principles into organizational, development, and architectural decisions
 
-Participants know how to develop and apply strategies to minimize AI risks. In particular, the participants know the following strategies:
+Participants are aware of the ethical issues that AI systems can create and know approaches and options for dealing with ethical problems, for example by creating AI guidelines. They have an overview of important ethical guidelines such as the “Ethics Guidelines for Trustworthy AI” of the EU.
 
-- Strengthening robustness through extensive testing
-- Fault-tolerant AI systems
-- Transparent development
-- Explainable AI
+Optionally, participants know important documents and frameworks on AI governance that can be used to develop the core principles of AI governance and responsible AI for an organization, for example:
 
-
-
-[[LG-2-10]]
-==== LG 2-10: Apply options for protection against attacks (AI security)
-
-Participants will be familiar with various options for protecting against attacks (AI security) and, in particular, they will be familiar with options for integrating security standards into the architecture and can take these into account for the design of the system.
-
-
-[[LG-2-11]]
-==== LG 2-11: Understanding the basic issues and facets of AI safety
-
-The participants understand the basic problems of AI safety and know the various facets of it. In particular, participants will be familiar with specific problems such as "AI model risks by poisoning" and "bias".
-
-
-[[LG-2-12]]
-==== LG 2-12: Understand ethical problems of AI systems and know approaches to dealing with them
-
-Participants are aware of the ethical problems that AI systems can bring with them and know approaches and possibilities for resolving these problems. This includes, for example, AI alignment (and its limits) and the creation of their own AI guidelines.
-
-
-[[LG-2-13]]
-==== LG 2-13: Overview of ethical guidelines
-
-The participants review important ethics guidelines such as the "EU Ethics Guidelines for trustworthy AI" and the "Google AI Ethics Guidelines".
-
-
-
-[[LG-2-14]]
-==== LG 2-14: Know the core principles of AI governance and responsible AI for companies
-
-The participants are familiar with the most important documents on AI governance in order to develop the core principles of AI governance and responsible AI for the company. This applies in particular to the following documents:
-
-- OECD AI Principles, https://oecd.ai/en/ai-principles
-- The Asilomar AI Principles, https://futureoflife.org/open-letter/ai-principles/
-- The IEEE Ethically Aligned Design framework, https://standards.ieee.org/wp-content/uploads/import/documents/other/ead_v2.pdf
-
-
-
-[[LG-2-15]]
-==== LG 2-15: Gain insight into the creation of regulatory sandboxes
-
-Participants will gain an insight into the creation of regulatory sandboxes to promote innovation and the possible legal consequences of non-compliance with the provisions of the AI Act.
-
-
-[[LG-2-16]]
-==== LG 2-16: Ensuring effective data management for the quality and security of data in AI applications
-
-Participants will know how effective data management ensures the quality and security of data in AI applications.
-
+* OECD AI Principles, https://oecd.ai/en/ai-principles
+* The Asilomar AI Principles, https://futureoflife.org/open-letter/ai-principles/
+* The IEEE Ethically Aligned Design framework, https://standards.ieee.org/wp-content/uploads/import/documents/other/ead_v2.pdf
 
 // end::EN[]

--- a/docs/02-module-block-2/02-learning-goals.adoc
+++ b/docs/02-module-block-2/02-learning-goals.adoc
@@ -32,15 +32,11 @@ Die Teilnehmer:innen kennen die Klassifikation von KI-Systemen nach den EU AI Ac
 
 
 [[LZ-2-4]]
-==== LZ 2-4: Urheberrechtsproblematik von KI-generierten Inhalten einordnen
+==== LZ 2-4: Urheberrecht, Offenheitsgrade und Lizenzbedingungen von KI-Modellen und KI-generierten Inhalten bewerten
 
-Die Teilnehmer:innen verstehen die Urheberrechtsproblematik für KI-generierte Inhalte und kennen die Auswirkungen auf bestimmte Softwarelizenzmodelle sowie mögliche Umgänge damit.
+Die Teilnehmer:innen können urheberrechtliche Fragestellungen bei Trainingsdaten und KI-generierten Inhalten einordnen und deren Auswirkungen auf Entwicklung, Bereitstellung und Nutzung von KI-Systemen erläutern.
 
-[[LZ-2-5]]
-==== LZ 2-5: Arten bzw. Grade der Offenheit sowie Arten von Lizenzen freier ML-Modelle überblicken
-
-Die Teilnehmer:innen überblicken verschiedene Arten bzw. Grade der Offenheit freier ML-Modelle. Das betrifft beispielsweise die Offenlegung der Daten
-und der Modellparameter. Darüber hinaus kennen sie verschiedene Arten von Lizenzen freier ML-Modelle sowie deren Auswirkungen auf das KI-System.
+Sie können unterschiedliche Grade der Offenheit von ML-Modellen, beispielsweise hinsichtlich Trainingsdaten, Quellcode, Modellarchitektur und Modellparametern, unterscheiden sowie Lizenzbedingungen und daraus resultierende Einschränkungen für ein KI-System bewerten.
 
 
 [[LZ-2-6]]

--- a/docs/02-module-block-2/02-learning-goals.adoc
+++ b/docs/02-module-block-2/02-learning-goals.adoc
@@ -51,7 +51,7 @@ Die Teilnehmer:innen können Regulatory Sandboxes als Instrument zur kontrollier
 
 
 [[LZ-2-8]]
-==== LZ 2-8: Fallstricke hinsichtlich Security sowie Angriffsarten auf ML-Modelle kennen
+==== LZ 2-8: Fallstricke hinsichtlich Security sowie Angriffsarten auf ML-Modelle kennen und geeignete Sicherheitsmaßnahmen gegen Angriffe auf KI-Systeme auswählen
 
 Die Teilnehmer:innen kennen mögliche Fallstricke hinsichtlich Security sowie typische Angriffsarten auf ML-Modelle. Dies betrifft beispielsweise:
 
@@ -60,6 +60,8 @@ Die Teilnehmer:innen kennen mögliche Fallstricke hinsichtlich Security sowie ty
 * Data Poisoning
 * Model Inversion & Extraction.
 
+Die Teilnehmer:innen kennen Sicherheitsmaßnahmen zur Absicherung gegen Angriffe (AI Security) und kennen insbesondere Möglichkeiten
+zur Integration von Sicherheitsstandards und Schutzmechanismen in Architektur, Schnittstellen und Betriebsmodell.
 
 [[LZ-2-9]]
 ==== LZ 2-9: Strategien zur KI-Risikominimierung kennen und anwenden
@@ -70,13 +72,6 @@ Die Teilnehmer:innen wissen, wie Strategien zur KI-Risikominimierung entwickelt 
 * Fehlertolerante KI-Systeme
 * Transparente Entwicklung
 * Erklärbare KI (explainable AI)
-
-
-[[LZ-2-10]]
-==== LZ 2-10: Sicherheitsmaßnahmen gegen Angriffe auf KI-Systeme auswählen und in Architektur, Schnittstellen, Betriebsmodell und Schutzmechanismen integrieren.
-
-Die Teilnehmer:innen kennen verschiedene Möglichkeiten zur Absicherung gegen Angriffe (AI Security) und insbesondere kennen sie Möglichkeiten
-zur Integration von Sicherheitsstandards in die Architektur und können diese beim Entwurf berücksichtigen.
 
 
 [[LZ-2-11]]

--- a/docs/02-module-block-2/02-learning-goals.adoc
+++ b/docs/02-module-block-2/02-learning-goals.adoc
@@ -82,16 +82,12 @@ spezifische Probleme wie beispielsweise "AI model risks by poisoning" und "Bias"
 
 Die Teilnehmer:innen wissen, wie Bias in Daten und Modellen erkannt und reduziert werden können, um Fairness und Gleichbehandlung in KI-Anwendungen sicherzustellen.
 
+
 [[LZ-2-12]]
-==== LZ 2-12: Ethische Probleme von KI-Systemen verstehen und Ansätze zum Umgang damit kennen
+==== LZ 2-12: Ethikleitlinien und Prinzipien von AI Governance in Organisations-, Entwicklungs- und Architekturentscheidungen übersetzen
 
-Die Teilnehmer:innen wissen um die Probleme hinsichtlich Ethik, die KI-Systeme mit sich bringen können und kennen Ansätze und Möglichkeiten, mit ethischen Problemen umzugehen. Dies umfasst beispielsweise  KI-Alignment (und dessen Grenzen) sowie die Erstellung eigener KI-Richtlinien.
-
-
-[[LZ-2-13]]
-==== LZ 2-13: Ethikleitlinien und Prinzipien von AI Governance in Organisations-, Entwicklungs- und Architekturentscheidungen übersetzen
-
-Die Teilnehmer:innen überblicken wichtige Ethik-Leitlinien wie die „EU-Ethik-Leitlinien für vertrauenswürdige KI“.
+Die Teilnehmer:innen wissen um die Probleme hinsichtlich Ethik, die KI-Systeme mit sich bringen können und kennen Ansätze und Möglichkeiten, mit ethischen Problemen umzugehen, bspw. durch Erstellung von KI-Richtlinien.
+Dazu überblicken die Teilnehmer:innen wichtige Ethik-Leitlinien wie die „EU-Ethik-Leitlinien für vertrauenswürdige KI“.
 
 Optional kennen die Teilnehmer:innen die wichtige Dokumente und Frameworks zu AI Governance, um die Kernprinzipien zu AI Governance und Responsible AI für das Unternehmen auszuarbeiten, z.B.:
 

--- a/docs/02-module-block-2/02-learning-goals.adoc
+++ b/docs/02-module-block-2/02-learning-goals.adoc
@@ -39,8 +39,8 @@ Die Teilnehmer:innen können urheberrechtliche Fragestellungen bei Trainingsdate
 Sie können unterschiedliche Grade der Offenheit von ML-Modellen, beispielsweise hinsichtlich Trainingsdaten, Quellcode, Modellarchitektur und Modellparametern, unterscheiden sowie Lizenzbedingungen und daraus resultierende Einschränkungen für ein KI-System bewerten.
 
 
-[[LZ-2-6]]
-==== LZ 2-6: Strategien zur Einhaltung regulatorischer Anforderungen definieren und geeignete Nachweis- und Dokumentationsartefakte für Modelle, Datensätze und Betriebsprozesse festlegen.
+[[LZ-2-5]]
+==== LZ 2-5: Strategien zur Einhaltung regulatorischer Anforderungen definieren und geeignete Nachweis- und Dokumentationsartefakte für Modelle, Datensätze und Betriebsprozesse festlegen.
 
 Die Teilnehmer:innen verstehen die Grundaussagen des EU AI Acts (insbesondere Transparenzpflichten) und kennen Strategien für deren Einhaltung sowie mögliche Herausforderungen dabei.
 
@@ -50,8 +50,8 @@ Sie können insbesondere Dokumentationsartefakte für Modelle, Datensätze, Prom
 Die Teilnehmer:innen können Regulatory Sandboxes als Instrument zur kontrollierten Erprobung innovativer KI-Systeme einordnen und deren Möglichkeiten, Grenzen und Konsequenzen bei Nichteinhaltung des EU AI Acts erläutern.
 
 
-[[LZ-2-8]]
-==== LZ 2-8: Fallstricke hinsichtlich Security sowie Angriffsarten auf ML-Modelle kennen und geeignete Sicherheitsmaßnahmen gegen Angriffe auf KI-Systeme auswählen
+[[LZ-2-6]]
+==== LZ 2-6: Fallstricke hinsichtlich Security sowie Angriffsarten auf ML-Modelle kennen und geeignete Sicherheitsmaßnahmen gegen Angriffe auf KI-Systeme auswählen
 
 Die Teilnehmer:innen kennen mögliche Fallstricke hinsichtlich Security sowie typische Angriffsarten auf ML-Modelle. Dies betrifft beispielsweise:
 
@@ -63,8 +63,8 @@ Die Teilnehmer:innen kennen mögliche Fallstricke hinsichtlich Security sowie ty
 Die Teilnehmer:innen kennen Sicherheitsmaßnahmen zur Absicherung gegen Angriffe (AI Security) und kennen insbesondere Möglichkeiten
 zur Integration von Sicherheitsstandards und Schutzmechanismen in Architektur, Schnittstellen und Betriebsmodell.
 
-[[LZ-2-9]]
-==== LZ 2-9: Strategien zur KI-Risikominimierung kennen und anwenden
+[[LZ-2-7]]
+==== LZ 2-7: Strategien zur KI-Risikominimierung kennen und anwenden
 
 Die Teilnehmer:innen wissen, wie Strategien zur KI-Risikominimierung entwickelt und angewendet werden können. Insbesondere kennen die Teilnehmer:innen die folgenden Strategien:
 
@@ -74,8 +74,8 @@ Die Teilnehmer:innen wissen, wie Strategien zur KI-Risikominimierung entwickelt 
 * Erklärbare KI (explainable AI)
 
 
-[[LZ-2-11]]
-==== LZ 2-11: Grundproblematik und Facetten von AI-Safety verstehen
+[[LZ-2-8]]
+==== LZ 2-8: Grundproblematik und Facetten von AI-Safety verstehen
 
 Die Teilnehmer:innen verstehen die Grundproblematik von AI-Safety und kennen die verschiedenen Facetten dazu. Insbesondere kennen die Teilnehmer:innen
 spezifische Probleme wie beispielsweise "AI model risks by poisoning" und "Bias".
@@ -83,8 +83,8 @@ spezifische Probleme wie beispielsweise "AI model risks by poisoning" und "Bias"
 Die Teilnehmer:innen wissen, wie Bias in Daten und Modellen erkannt und reduziert werden können, um Fairness und Gleichbehandlung in KI-Anwendungen sicherzustellen.
 
 
-[[LZ-2-12]]
-==== LZ 2-12: Ethikleitlinien und Prinzipien von AI Governance in Organisations-, Entwicklungs- und Architekturentscheidungen übersetzen
+[[LZ-2-9]]
+==== LZ 2-9: Ethikleitlinien und Prinzipien von AI Governance in Organisations-, Entwicklungs- und Architekturentscheidungen übersetzen
 
 Die Teilnehmer:innen wissen um die Probleme hinsichtlich Ethik, die KI-Systeme mit sich bringen können und kennen Ansätze und Möglichkeiten, mit ethischen Problemen umzugehen, bspw. durch Erstellung von KI-Richtlinien.
 Dazu überblicken die Teilnehmer:innen wichtige Ethik-Leitlinien wie die „EU-Ethik-Leitlinien für vertrauenswürdige KI“.

--- a/docs/02-module-block-2/references.adoc
+++ b/docs/02-module-block-2/references.adoc
@@ -1,8 +1,8 @@
 === {references}
 
-<<engler>>, <<nist>>, <<hall>>, <<masood>>, <<csiro>>,
-<<pruksachatkun>>, <<chen>>, <<atlas>>, <<visenger-links>>,
-<<eu-ai-act>>, <<hotz>>, <<bhajaria>>, <<jarmul>>, <<molnar>>
+<<atlas>>, <<bhajaria>>, <<chen>>, <<csiro>>, <<engler>>, <<eu-ai-act>>,
+<<gharbi>>, <<hall>>, <<hotz>>, <<jarmul>>, <<masood>>, <<molnar>>,
+<<nist>>, <<pruksachatkun>>, <<visenger-links>>
 
 // tag::DE[]
 // end::DE[]

--- a/docs/02-module-block-2/references.adoc
+++ b/docs/02-module-block-2/references.adoc
@@ -1,6 +1,6 @@
 === {references}
 
-<<atlas>>, <<bhajaria>>, <<chen>>, <<csiro>>, <<engler>>, <<eu-ai-act>>,
+<<atlas>>, <<bhajaria>>, <<chen>>, <<csiro>>, <<eu-ai-act>>,
 <<gharbi>>, <<hall>>, <<hotz>>, <<jarmul>>, <<masood>>, <<molnar>>,
 <<nist>>, <<pruksachatkun>>, <<visenger-links>>
 

--- a/docs/03-module-block-3/02-learning-goals.adoc
+++ b/docs/03-module-block-3/02-learning-goals.adoc
@@ -22,8 +22,8 @@ Die Teilnehmer:innen kennen typische Vorgehensmodelle für die Softwareentwicklu
 * Team Data Science Process
 * GenAI Life Cycle.
 
-[[LZ-3-3]]
-==== LZ 3-3: Datenarten und Anforderungen an Daten sowie typische ML-Problemstellungen und deren Anforderungen verstehen
+[[LZ-3-2]]
+==== LZ 3-2: Datenarten und Anforderungen an Daten sowie typische ML-Problemstellungen und deren Anforderungen verstehen
 
 Die Teilnehmer:innen kennen verschiedene Arten von Daten sowie typische ML-Probleme und Anwendungsfälle für die Nutzung der Daten aus den Bereichen:
 
@@ -44,8 +44,8 @@ und verstehen, welche Anforderungen diese haben können, z.B.:
 Insbesondere haben die Teilnehmer:innen ein gutes Verständnis für die Notwendigkeit von Validierung und Kenntnis der typischen Datenaufteilung in Trainings-, Validierungs- und Testdaten.
 
 
-[[LZ-3-7]]
-==== LZ 3-7: Geeignete Architektur- und Design-Patterns für KI-Systeme auswählen, gegeneinander abwägen und anhand von Qualitätsanforderungen begründen.
+[[LZ-3-3]]
+==== LZ 3-3: Geeignete Architektur- und Design-Patterns für KI-Systeme auswählen, gegeneinander abwägen und anhand von Qualitätsanforderungen begründen.
 
 Die Teilnehmer:innen wissen, welche Design Patterns für KI-Systeme existieren und wie man passende Patterns auswählt. Das betrifft die folgenden Design Patterns:
 
@@ -58,8 +58,8 @@ Die Teilnehmer:innen wissen, welche Design Patterns für KI-Systeme existieren u
 Insbesondere kennen die Teilnehmer:innen Transfer-Learning bzw. Fine-Tuning als Möglichkeit, um die vortrainierten Basismodelle auf bestehende Anwendungsfälle zu adoptieren.
 
 
-[[LZ-3-11]]
-==== LZ 3-11: Metriken zur Messung der Performance von ML-Modellen kennen
+[[LZ-3-4]]
+==== LZ 3-4: Metriken zur Messung der Performance von ML-Modellen kennen
 
 Die Teilnehmer:innen kennen verschiedene Metriken zur Messung der Performance von ML-Modellen wie beispielsweise:
 
@@ -69,54 +69,54 @@ Die Teilnehmer:innen kennen verschiedene Metriken zur Messung der Performance vo
 
 und wissen, wie man Bewertungskriterien zur Leistungsbeurteilung festlegt.
 
-[[LZ-3-12]]
-==== LZ 3-12: KI-Komponenten über geeignete Integrationsmuster, Schnittstellen und Entkopplungsmechanismen in bestehende Systeme und Domänenarchitekturen integrieren.
+[[LZ-3-5]]
+==== LZ 3-5: KI-Komponenten über geeignete Integrationsmuster, Schnittstellen und Entkopplungsmechanismen in bestehende Systeme und Domänenarchitekturen integrieren.
 
 Die Teilnehmer:innen verstehen, wie ML-Modelle in bestehende Systeme integriert werden können und kennen die Schnittstellen und Integrationspunkte.
 
-[[LZ-3-13]]
-==== LZ 3-13: Benutzerinteraktionen für KI-Systeme so gestalten, dass Unsicherheit, Erklärbarkeit, Freigaben und Human-in-the-Loop angemessen berücksichtigt werden.
+[[LZ-3-6]]
+==== LZ 3-6: Benutzerinteraktionen für KI-Systeme so gestalten, dass Unsicherheit, Erklärbarkeit, Freigaben und Human-in-the-Loop angemessen berücksichtigt werden.
 
 Die Teilnehmer:innen wissen, wie Benutzeroberflächen gestaltet werden sollten, um effektive Interaktionen mit dem ML-System zu ermöglichen und die Benutzererfahrung zu optimieren.
 
-[[LZ-3-14]]
-==== LZ 3-14: Leistung und Skalierbarkeit von KI-Systemen analysieren und gestalten
+[[LZ-3-7]]
+==== LZ 3-7: Leistung und Skalierbarkeit von KI-Systemen analysieren und gestalten
 
 Die Teilnehmer:innen verstehen die Bedeutung von Leistungskennzahlen wie Latenz, Durchsatz und Resourcenauslastung in KI-Systemen für Training sowie Inferenz und verstehen,
 wie diese optimiert werden können.
 
 Sie können Ursachen von Leistungs- und Skalierungsproblemen analysieren und geeignete Maßnahmen auswählen, damit KI-Systeme steigende Datenmengen, Nutzerzahlen und Anfragevolumen verarbeiten können.
 
-[[LZ-3-16]]
-==== LZ 3-16: Robustheit in KI-Systemen verstehen und Strategien zur Erhöhung der Robustheit anwenden
+[[LZ-3-8]]
+==== LZ 3-8: Robustheit in KI-Systemen verstehen und Strategien zur Erhöhung der Robustheit anwenden
 
 Die Teilnehmer:innen haben ein Verständnis davon, was Robustheit in KI-Systemen bedeutet,
 und können Strategien zur Erhöhung der Robustheit in verschiedenen Anwendungskontexten anwenden.
 
-[[LZ-3-17]]
-==== LZ 3-17: Zuverlässigkeit und Verfügbarkeit von KI-Systemen einordnen
+[[LZ-3-9]]
+==== LZ 3-9: Zuverlässigkeit und Verfügbarkeit von KI-Systemen einordnen
 
 Die Teilnehmer:innen verstehen die Konzepte der Zuverlässigkeit und Verfügbarkeit und wissen, wie sie KI-Systeme bauen, die stabil und konstant verfügbar sind.
 
-[[LZ-3-18]]
-==== LZ 3-18: Maßnahmen für Reproduzierbarkeit, Auditierbarkeit und Nachvollziehbarkeit von Modellen, Datenständen, Prompts, Konfigurationen und Ergebnissen festlegen.
+[[LZ-3-10]]
+==== LZ 3-10: Maßnahmen für Reproduzierbarkeit, Auditierbarkeit und Nachvollziehbarkeit von Modellen, Datenständen, Prompts, Konfigurationen und Ergebnissen festlegen.
 
 Die Teilnehmer:innen wissen, wie wichtig es ist, dass KI-Ergebnisse reproduzierbar und prüfbar sind, und wissen, welche Methoden zur Sicherstellung dieser Eigenschaften eingesetzt werden können.
 
 
-[[LZ-3-20]]
-==== LZ 3-20: Erklärbarkeit und Interpretierbarkeit in KI-Systemen einordnen
+[[LZ-3-11]]
+==== LZ 3-11: Erklärbarkeit und Interpretierbarkeit in KI-Systemen einordnen
 
 Die Teilnehmer:innen verstehen die Bedeutung von Erklärbarkeit und Interpretierbarkeit in KI-Systemen und wissen,
 wie man diese sicherstellen kann, um Vertrauen und Transparenz zu fördern.
 
-[[LZ-3-22]]
-==== LZ 3-22: Fehlertoleranz in KI-Systemen kennen
+[[LZ-3-12]]
+==== LZ 3-12: Fehlertoleranz in KI-Systemen kennen
 
 Die Teilnehmer:innen kennen die Konzepte der Fehlertoleranz und können erläutern, wie KI-Systeme trotz Fehlern oder Störungen funktionsfähig bleiben.
 
-[[LZ-3-23]] 
-==== LZ 3-23: Architekturentscheidungen für KI-Systeme dokumentieren.
+[[LZ-3-13]]
+==== LZ 3-13: Architekturentscheidungen für KI-Systeme dokumentieren.
 
 Die Teilnehmer:innen wissen, wie man die Anwendungsfälle bzw. Aufgaben eines ML-Modells definiert und dokumentiert, wie beispielsweise die Klassifikation von Bildern oder die Erkennung von Betrug, insbesondere Trade-offs zu:
 * RAG versus Fine-Tuning

--- a/docs/03-module-block-3/02-learning-goals.adoc
+++ b/docs/03-module-block-3/02-learning-goals.adoc
@@ -132,7 +132,6 @@ Die Teilnehmer:innen wissen, wie man die Anwendungsfälle / Aufgaben eines ML-Mo
 * Batch versus Realtime
 * Zentralem versus domänenspezifischem KI-Service.
 
-Die Teilnehmer:innen kennen // TODO
 
 // end::DE[]
 

--- a/docs/03-module-block-3/02-learning-goals.adoc
+++ b/docs/03-module-block-3/02-learning-goals.adoc
@@ -66,7 +66,7 @@ Die Teilnehmer:innen kennen Transfer-Learning bzw. Fine-Tuning als Möglichkeit,
 
 
 [[LZ-3-8]]
-==== LZ 3-8: Design Patterns für KI-Systeme auswählen
+==== LZ 3-8: Geeignete Architektur- und Design-Patterns für KI-Systeme auswählen, gegeneinander abwägen und anhand von Qualitätsanforderungen begründen.
 
 Die Teilnehmer:innen wissen, welche Design Patterns für KI-Systeme existieren und wie man passende Patterns auswählt. Das betrifft die folgenden Design Patterns:
 
@@ -100,12 +100,12 @@ Die Teilnehmer:innen kennen verschiedene Metriken zur Messung der Performance vo
 und wissen, wie man Bewertungskriterien zur Leistungsbeurteilung festlegt.
 
 [[LZ-3-12]]
-==== LZ 3-12: ML-Modelle in bestehende Systeme integrieren
+==== LZ 3-12: KI-Komponenten über geeignete Integrationsmuster, Schnittstellen und Entkopplungsmechanismen in bestehende Systeme und Domänenarchitekturen integrieren.
 
 Die Teilnehmer:innen verstehen, wie ML-Modelle in bestehende Systeme integriert werden können und kennen die Schnittstellen und Integrationspunkte.
 
 [[LZ-3-13]]
-==== LZ 3-13: Benutzeroberflächen für KI-Systeme gestalten
+==== LZ 3-13: Benutzerinteraktionen für KI-Systeme so gestalten, dass Unsicherheit, Erklärbarkeit, Freigaben und Human-in-the-Loop angemessen berücksichtigt werden.
 
 Die Teilnehmer:innen wissen, wie Benutzeroberflächen gestaltet werden sollten, um effektive Interaktionen mit dem ML-System zu ermöglichen und die Benutzererfahrung zu optimieren.
 
@@ -127,14 +127,13 @@ wie man KI-Systeme entwickelt, die mit steigenden Datenvolumen umgehen können, 
 Die Teilnehmer:innen haben ein Verständnis davon, was Robustheit in KI-Systemen bedeutet,
 und können Strategien zur Erhöhung der Robustheit in verschiedenen Anwendungskontexten anwenden.
 
-
 [[LZ-3-17]]
 ==== LZ 3-17: Zuverlässigkeit und Verfügbarkeit von KI-Systemen einordnen
 
 Die Teilnehmer:innen verstehen die Konzepte der Zuverlässigkeit und Verfügbarkeit und wissen, wie sie KI-Systeme bauen, die stabil und konstant verfügbar sind.
 
 [[LZ-3-18]]
-==== LZ 3-18: Reproduzierbarkeit und Prüfbarkeit von KI-Ergebnisse verstehen
+==== LZ 3-18: Maßnahmen für Reproduzierbarkeit, Auditierbarkeit und Nachvollziehbarkeit von Modellen, Datenständen, Prompts, Konfigurationen und Ergebnissen festlegen.
 
 Die Teilnehmer:innen wissen, wie wichtig es ist, dass KI-Ergebnisse reproduzierbar und prüfbar sind, und wissen, welche Methoden zur Sicherstellung dieser Eigenschaften eingesetzt werden können.
 
@@ -160,6 +159,9 @@ Die Teilnehmer:innen wissen, wie Bias in Daten und Modellen erkannt und reduzier
 ==== LZ 3-22: Fehlertoleranz in KI-Systemen kennen
 
 Die Teilnehmer:innen kennen die Konzepte der Fehlertoleranz und können erläutern, wie KI-Systeme trotz Fehlern oder Störungen funktionsfähig bleiben.
+
+[[LZ-3-23]] 
+==== LZ 3-23: Architekturentscheidungen für KI-Systeme dokumentieren, insbesondere Trade-offs zu RAG versus Fine-Tuning, SaaS versus Self-Hosting, Batch versus Realtime und zentralem versus domänenspezifischem KI-Service.
 
 // end::DE[]
 

--- a/docs/03-module-block-3/02-learning-goals.adoc
+++ b/docs/03-module-block-3/02-learning-goals.adoc
@@ -129,169 +129,129 @@ Die Teilnehmer:innen wissen, wie man die Anwendungsfälle bzw. Aufgaben eines ML
 
 // tag::EN[]
 [[LG-3-1]]
-==== LG 3-1: Understanding the life cycle of a machine learning or data science project
+==== LG 3-1: Understand the life cycle of a machine learning or data science project
 
 Participants have an understanding of the life cycle of a machine learning or data science project. In particular, they are familiar with the following phases:
 
-- Exploratory Data Analysis
-- Data cleansing and preparation
-- Feature Engineering
-- Model training and selection
-- POC
-- Deployment
-- Maintenance
+* Exploratory data analysis
+* Data cleansing and preparation
+* Feature engineering
+* Model training and selection
+* POC
+* Deployment
+* Maintenance
+
+
+Participants know typical process models for the software development of AI systems. These include, for example:
+
+* CRISP-ML(Q)
+* Team Data Science Process
+* GenAI Life Cycle
 
 
 [[LG-3-2]]
-==== LG 3-2: Knowing process models for the software development of AI systems
-Participants will be familiar with typical process models for the software development of AI systems. These are, for example
+==== LG 3-2: Understand data types and requirements as well as typical ML problems and their requirements
 
-- CRISP-ML(Q)
-- Team Data Science Process
-- GenAI Life Cycle.
+Participants know different types of data as well as typical ML problems and use cases involving data from the following areas:
 
+* Supervised learning
+* Unsupervised learning
+* Reinforcement learning
+
+They understand the requirements these may have, for example:
+
+* Availability of correct labels of different types
+* Data volume and diversity
+* Temporal or semantic dependencies in data features
+* Encoding the input data of ML models, for example:
+** One-hot encodings
+** Label encodings
+** Embeddings
+
+
+In particular, participants have a good understanding of the need for validation and of the typical division of data into training, validation, and test datasets.
 
 [[LG-3-3]]
-==== LG 3-3: Know types of and requirements for data and typical ML problems
+==== LG 3-3: Select and compare suitable architecture and design patterns for AI systems and justify the selection based on quality requirements
 
-Participants know different types of data and typical ML problems as well as use cases for utilizing the data. In addition, the participants have an understanding of various requirements for the data, e.g. the presence of correct labels of various types.
+Participants know which design patterns exist for AI systems and how to select suitable patterns. This includes the following design patterns:
+
+* ML systems topology patterns
+* Pipeline architecture patterns
+* Model training patterns
+* Model serving patterns
+* Model deployment patterns
+
+In particular, participants know transfer learning and fine-tuning as ways to adapt pretrained foundation models to existing use cases.
+
 
 [[LG-3-4]]
-==== LG 3-4: Understanding machine learning problems and their requirements
-
-The participants understand the various machine learning problems such as
-
-- Supervised Learning
-- Unsupervised Learning
-- Reinforcement Learning
-
-and know what requirements they have.
-
-
-
-[[LG-3-5]]
-==== LG 3-5: Use input data for various AI algorithms
-
-Participants know which data is required for AI algorithms and have a good understanding of the need for validation and knowledge of the typical data breakdown into training, validation and test data. In addition, participants have a good understanding of the input data required for various AI algorithms such as
-
-- Neural networks as numerical vectors and matrices or tensors
-- One-Hot-Encodings
-- embeddings
-
-are required.
-
-
-
-[[LG-3-6]]
-==== LG 3-6: Dealing with challenges such as non-determinism, data quality and concept and model drift
-
-
-Participants understand how to deal with challenges such as non-determinism, data quality and concept and model drift.
-
-[[LG-3-7]]
-==== LG 3-7: Knowing transfer learning or fine-tuning
-
-The participants are familiar with transfer learning and fine-tuning as a way of incorporating the pre-trained basic models into existing use cases.
-
-
-[[LG-3-8]]
-==== LG 3-8: Selecting design patterns for AI systems
-
-Participants will know which design patterns exist for AI systems and how to select suitable patterns. This concerns the following design patterns:
-
-- ML Systems Topology Patterns
-- Pipeline Architecture Patterns
-- Model Training Pattern
-- Model Serving Patterns
-- Model Deployment Patterns
-
-
-
-[[LG-3-9]]
-==== LG 3-9: Define the task of an ML model
-
-The participants know how to define the use cases / tasks of an ML model, such as the classification of images or fraud detection.
-
-
-[[LG-3-10]]
-==== LG 3-10: Understand and specify inputs and outputs for the functioning of an ML system
-
-Participants understand which inputs and outputs are required for the functioning of an ML system and can specify them.
-
-
-[[LG-3-11]]
-==== LG 3-11: Know metrics for measuring the performance of ML models
+==== LG 3-4: Know metrics for measuring the performance of ML models
 
 Participants are familiar with various metrics for measuring the performance of ML models, such as:
 
-- Precision, Recall
-- F1 Score
-- Accuracy
+* Precision, recall
+* F1 score
+* Accuracy
 
 and know how to define evaluation criteria for performance assessment.
 
 
-[[LG-3-12]]
-==== LG 3-12: Integrating ML models into existing systems
+[[LG-3-5]]
+==== LG 3-5: Integrate AI components into existing systems and domain architectures using suitable integration patterns, interfaces, and decoupling mechanisms
 
 Participants understand how ML models can be integrated into existing systems and are familiar with the interfaces and integration points.
 
-[[LG-3-13]]
-==== LG 3-13: Designing user interfaces for AI systems
+[[LG-3-6]]
+==== LG 3-6: Design user interactions for AI systems that appropriately account for uncertainty, explainability, approvals, and human-in-the-loop
 
 Participants know how user interfaces should be designed to enable effective interactions with the ML system and optimize the user experience.
 
 
-[[LG-3-14]]
-==== LG 3-14: Understanding performance metrics such as latency and throughput in AI systems
+[[LG-3-7]]
+==== LG 3-7: Analyze and design the performance and scalability of AI systems
 
-Participants understand the importance of key performance indicators such as latency and throughput in AI systems and know how these can be optimized.
+Participants understand the importance of performance indicators such as latency, throughput, and resource utilization in AI systems for both training and inference, and understand how these can be optimized.
 
-
-[[LG-3-15]]
-==== LG 3-15: Managing scalability for increased data volumes
-
-Participants understand the importance of scalability for increased data volumes and know how to develop AI systems that can handle increasing data volumes without losing performance.
+They can analyze the causes of performance and scalability problems and select suitable measures that enable AI systems to handle growing data volumes, numbers of users, and request volumes.
 
 
-[[LG-3-16]]
-==== LG 3-16: Understanding robustness in AI systems and applying strategies to increase robustness
+[[LG-3-8]]
+==== LG 3-8: Understand robustness in AI systems and apply strategies to increase robustness
 
 Participants have an understanding of what robustness means in AI systems and can apply strategies to increase robustness in different application contexts.
 
 
-[[LG-3-17]]
-==== LG 3-17: Classify the reliability and availability of AI systems
+[[LG-3-9]]
+==== LG 3-9: Classify the reliability and availability of AI systems
 
 Participants understand the concepts of reliability and availability and know how to build AI systems that are stable and constantly available.
 
 
-[[LG-3-18]]
-==== LG 3-18: Understanding the reproducibility and testability of AI results
+[[LG-3-10]]
+==== LG 3-10: Specify measures for the reproducibility, auditability, and traceability of models, dataset versions, prompts, configurations, and results
 
-The participants know how important it is that AI results are reproducible and testable and know which methods can be used to ensure these properties.
+Participants know the importance of AI results being reproducible and auditable and know which methods can be used to ensure these properties.
 
-[[LG-3-19]]
-==== LG 3-19: Know security, data protection and compliance requirements
-
-Participants are familiar with the requirements for security, data protection and compliance and know how these are implemented in AI systems.
-
-
-[[LG-3-20]]
-==== LG 3-20: Classify explainability and interpretability in AI systems
+[[LG-3-11]]
+==== LG 3-11: Classify explainability and interpretability in AI systems
 
 Participants understand the importance of explainability and interpretability in AI systems and know how to ensure this in order to promote trust and transparency.
 
 
-[[LG-3-21]]
-==== LG 3-21: Recognizing bias in data and models
-
-The participants know how bias in data and models can be recognized and reduced in order to ensure fairness and equal treatment in AI applications.
-
-
-[[LG-3-22]]
-==== LG 3-22: Knowing fault tolerance in AI systems
+[[LG-3-12]]
+==== LG 3-12: Know fault tolerance in AI systems
 
 Participants are familiar with the concepts of fault tolerance and can explain how AI systems remain functional despite errors or malfunctions.
+
+[[LG-3-13]]
+==== LG 3-13: Document architectural decisions for AI systems
+
+Participants know how to define and document the use cases or tasks of an ML model, such as image classification or fraud detection, particularly the trade-offs between:
+
+* RAG versus fine-tuning
+* SaaS versus self-hosting
+* Batch versus real time
+* A centralized versus a domain-specific AI service
 
 // end::EN[]

--- a/docs/03-module-block-3/02-learning-goals.adoc
+++ b/docs/03-module-block-3/02-learning-goals.adoc
@@ -45,13 +45,7 @@ Insbesondere haben die Teilnehmer:innen ein gutes Verständnis für die Notwendi
 
 
 [[LZ-3-7]]
-==== LZ 3-7: Transfer-Learning bzw. Fine-Tuning kennen
-
-Die Teilnehmer:innen kennen Transfer-Learning bzw. Fine-Tuning als Möglichkeit, um die vortrainierten Basismodelle auf bestehende Anwendungsfälle zu adoptieren.
-
-
-[[LZ-3-8]]
-==== LZ 3-8: Geeignete Architektur- und Design-Patterns für KI-Systeme auswählen, gegeneinander abwägen und anhand von Qualitätsanforderungen begründen.
+==== LZ 3-7: Geeignete Architektur- und Design-Patterns für KI-Systeme auswählen, gegeneinander abwägen und anhand von Qualitätsanforderungen begründen.
 
 Die Teilnehmer:innen wissen, welche Design Patterns für KI-Systeme existieren und wie man passende Patterns auswählt. Das betrifft die folgenden Design Patterns:
 
@@ -60,6 +54,8 @@ Die Teilnehmer:innen wissen, welche Design Patterns für KI-Systeme existieren u
 * Model Training Pattern
 * Model Serving Patterns
 * Model Deployment Patterns
+
+Insbesondere kennen die Teilnehmer:innen Transfer-Learning bzw. Fine-Tuning als Möglichkeit, um die vortrainierten Basismodelle auf bestehende Anwendungsfälle zu adoptieren.
 
 
 [[LZ-3-11]]

--- a/docs/03-module-block-3/02-learning-goals.adoc
+++ b/docs/03-module-block-3/02-learning-goals.adoc
@@ -80,16 +80,12 @@ Die Teilnehmer:innen verstehen, wie ML-Modelle in bestehende Systeme integriert 
 Die Teilnehmer:innen wissen, wie Benutzeroberflächen gestaltet werden sollten, um effektive Interaktionen mit dem ML-System zu ermöglichen und die Benutzererfahrung zu optimieren.
 
 [[LZ-3-14]]
-==== LZ 3-14: Leistungskennzahlen wie Latenz und Durchsatz in KI-Systemen verstehen
+==== LZ 3-14: Leistung und Skalierbarkeit von KI-Systemen analysieren und gestalten
 
-Die Teilnehmer:innen verstehen die Bedeutung von Leistungskennzahlen wie Latenz und Durchsatz in KI-Systemen und wissen,
+Die Teilnehmer:innen verstehen die Bedeutung von Leistungskennzahlen wie Latenz, Durchsatz und Resourcenauslastung in KI-Systemen für Training sowie Inferenz und verstehen,
 wie diese optimiert werden können.
 
-[[LZ-3-15]]
-==== LZ 3-15: Mit Skalierbarkeit auf erhöhten Datenmengen umgehen
-
-Die Teilnehmer:innen verstehen die Bedeutung der Skalierbarkeit auf erhöhte Datenmengen und wissen,
-wie man KI-Systeme entwickelt, die mit steigenden Datenvolumen umgehen können, ohne an Leistung zu verlieren.
+Sie können Ursachen von Leistungs- und Skalierungsproblemen analysieren und geeignete Maßnahmen auswählen, damit KI-Systeme steigende Datenmengen, Nutzerzahlen und Anfragevolumen verarbeiten können.
 
 [[LZ-3-16]]
 ==== LZ 3-16: Robustheit in KI-Systemen verstehen und Strategien zur Erhöhung der Robustheit anwenden
@@ -122,7 +118,7 @@ Die Teilnehmer:innen kennen die Konzepte der Fehlertoleranz und können erläute
 [[LZ-3-23]] 
 ==== LZ 3-23: Architekturentscheidungen für KI-Systeme dokumentieren.
 
-Die Teilnehmer:innen wissen, wie man die Anwendungsfälle / Aufgaben eines ML-Modells definiert und dokumentiert, wie beispielsweise die Klassifikation von Bildern oder die Erkennung von Betrug, insbesondere Trade-offs zu:
+Die Teilnehmer:innen wissen, wie man die Anwendungsfälle bzw. Aufgaben eines ML-Modells definiert und dokumentiert, wie beispielsweise die Klassifikation von Bildern oder die Erkennung von Betrug, insbesondere Trade-offs zu:
 * RAG versus Fine-Tuning
 * SaaS versus Self-Hosting
 * Batch versus Realtime

--- a/docs/03-module-block-3/references.adoc
+++ b/docs/03-module-block-3/references.adoc
@@ -1,6 +1,6 @@
 === {references}
 
-<<alake>>, <<bornstein>>, <<cdteliot>>, <<crowe>>, <<gharbi>>, <<heiland>>,
+<<bornstein>>, <<cdteliot>>, <<crowe>>, <<gharbi>>, <<heiland>>,
 <<hotz-two>>, <<hotz-three>>, <<koc>>, <<lakshmanan>>,
 <<mlsoftwarearchitecture>>, <<nahar>>, <<saltz>>, <<savarese>>, <<serban>>,
 <<studer>>, <<tdcox>>, <<tuberlin>>, <<visenger-three>>, <<zaharia>>

--- a/docs/03-module-block-3/references.adoc
+++ b/docs/03-module-block-3/references.adoc
@@ -1,15 +1,9 @@
 === {references}
 
-<<tuberlin>>, <<bornstein>>,
-<<crowe>>, <<lakshmanan>>,
-<<alake>>, <<koc>>,
-<<cdteliot>>, <<visenger-three>>,
-<<zaharia>>, <<savarese>>,
-<<tdcox>>, <<studer>>,
-<<hotz-two>>, <<hotz-three>>,
-<<saltz>>, <<serban>>,
-<<heiland>>, <<nahar>>,
-<<mlsoftwarearchitecture>>,
+<<alake>>, <<bornstein>>, <<cdteliot>>, <<crowe>>, <<gharbi>>, <<heiland>>,
+<<hotz-two>>, <<hotz-three>>, <<koc>>, <<lakshmanan>>,
+<<mlsoftwarearchitecture>>, <<nahar>>, <<saltz>>, <<savarese>>, <<serban>>,
+<<studer>>, <<tdcox>>, <<tuberlin>>, <<visenger-three>>, <<zaharia>>
 
 // tag::DE[]
 // end::DE[]

--- a/docs/04-module-block-4/02-learning-goals.adoc
+++ b/docs/04-module-block-4/02-learning-goals.adoc
@@ -57,49 +57,51 @@ Die Teilnehmer:innen kennen grundlegende Konzepte moderner Datenarchitekturen f√
 
 // tag::EN[]
 [[LG-4-1]]
-==== LG 4-1: Acquiring and labeling data
+==== LG 4-1: Acquire and label data
 
-Participants gain an overview of various methods for acquiring and labeling data.
+Participants have an overview of various methods for acquiring and labeling data.
+
+[OPTIONAL]
+Participants know relevant data-labeling tools such as CVAT, Label Studio, or Amazon Mechanical Turk.
 
 [[LG-4-2]]
-==== LG 4-2: Know common platforms for publicly accessible data
+==== LG 4-2: Evaluate the sources and suitability of publicly available datasets in terms of quality, licensing, representativeness, and risks
+
 Participants can name common platforms for publicly accessible data.
 
 [[LG-4-3]]
-==== LG 4-3: Overview of relevant tools for data labeling
+==== LG 4-3: Design data pipelines and data architectures for AI systems that support quality, traceability, scalability, governance, and reusability
 
-The participants know relevant tools for data labeling such as CVAT, Amazon Mechanical Turk.
+Participants understand the design of efficient data pipelines and architectures, the consideration of data quality, and storage solutions and their management. To this end, participants know:
 
+* Architecture patterns for data engineering pipelines and ETL processes
+* How effective data management ensures the quality and security of data in AI applications
+
+[OPTIONAL]
+Participants have an overview of relevant tools for data engineering pipelines, such as Apache Spark and Flink.
 
 [[LG-4-4]]
-==== LG 4-4: Designing efficient data pipelines and architectures
+==== LG 4-4: Know strategies for data aggregation, cleansing, transformation, enrichment, and augmentation
 
-The participants have an understanding of the design of efficient data pipelines and data architectures, and they understand how to consider data quality for storage solutions and their management.
-To this end, participants are familiar with architectural patterns for data engineering pipelines and ETL processes.
-
+Participants know strategies for data aggregation, cleansing, transformation, enrichment, and augmentation.
 
 [[LG-4-5]]
-==== LG 4-5: Know strategies for data aggregation, cleansing, transformation, enrichment and augmentation
+==== LG 4-5: Know options for storing data
 
-The participants know strategies for data aggregation, cleansing, transformation, enrichment and augmentation.
+Participants know various options for storing data as well as their advantages and disadvantages. The options include the following technologies:
 
+* CSV files
+* Column-oriented files
+* Relational and document databases
+* Data warehouses
+* Data lakes
+* Vector databases
+* Graph databases
 
 [[LG-4-6]]
-==== LG 4-6: Overview of tools for data engineering pipelines
+==== LG 4-6: Classify data products, data contracts, and responsibilities in data architectures for AI systems and use them to establish robust interfaces between the business domain, data platform, and AI components
 
-Participants will gain an overview of relevant tools for data engineering pipelines such as Apache Spark and Flink.
-
-
-[[LG-4-7]]
-==== LG 4-7: Know the options for storing data
-
-Participants will be familiar with various options for storing data as well as their advantages and disadvantages. The options include the following technologies:
-
-- CSV files
-- Column-oriented files
-- Relational and NoSQL databases
-- Data warehouses
-- Data Lakes
+Participants know fundamental concepts of modern data architectures for AI systems and understand the role of data products, data contracts, and business and technical responsibilities in stable and scalable data flows.
 
 
 // end::EN[]

--- a/docs/04-module-block-4/02-learning-goals.adoc
+++ b/docs/04-module-block-4/02-learning-goals.adoc
@@ -52,10 +52,6 @@ Die Teilnehmer:innen kennen verschiedene Möglichkeiten zur Speicherung der Date
 
 Die Teilnehmer:innen kennen grundlegende Konzepte moderner Datenarchitekturen für KI-Systeme und verstehen die Rolle von Data Products, Data Contracts sowie fachlicher und technischer Verantwortlichkeiten für stabile und skalierbare Datenflüsse.
 
-[[LZ-4-8]]
-==== LZ 4-8: Data Products, Data Contracts und Verantwortlichkeiten in Datenarchitekturen für KI-Systeme einordnen und für robuste Schnittstellen zwischen Fachlichkeit, Datenplattform und KI-Komponenten nutzen.
-
-Die Teilnehmer:innen kennen grundlegende Konzepte moderner Datenarchitekturen für KI-Systeme und verstehen die Rolle von Data Products, Data Contracts sowie fachlicher und technischer Verantwortlichkeiten für stabile und skalierbare Datenflüsse.
 
 // end::DE[]
 

--- a/docs/04-module-block-4/02-learning-goals.adoc
+++ b/docs/04-module-block-4/02-learning-goals.adoc
@@ -8,17 +8,17 @@
 Die Teilnehmer:innen überblicken verschiedene Methoden, um Daten zu akquirieren und Daten zu labeln.
 
 [[LZ-4-2]]
-==== LZ 4-2: Gängige Plattformen für öffentlich zugängliche Daten kennen
+==== LZ 4-2: Quellen und Eignung öffentlich verfügbarer Datensätze hinsichtlich Qualität, Lizenz, Repräsentativität und Risiken bewerten.
 
 Die Teilnehmer:innen können gängige Plattformen für öffentlich zugängliche Daten nennen.
 
 [[LZ-4-3]]
-==== LZ 4-3: Relevante Werkzeuge für das Daten-Labeln überblicken
+==== LZ 4-3 [OPTIONAL]: Verfahren und Werkzeuge für Datenannotation beispielhaft einordnen.
 
 Die Teilnehmer:innen kennen relevante Werkzeuge fürs Daten-Labeln wie beispielsweise CVAT, Amazon Mechanical Turk.
 
 [[LZ-4-4]]
-==== LZ 4-4: Effiziente Datenpipelines und -architekturen entwerfen
+==== LZ 4-4: Datenpipelines und Datenarchitekturen für KI-Systeme so entwerfen, dass Qualität, Nachvollziehbarkeit, Skalierbarkeit, Governance und Wiederverwendbarkeit unterstützt werden.
 
 Die Teilnehmer:innen haben ein Verständnis für die Gestaltung effizienter Datenpipelines und -architekturen, die Betrachtung von Datenqualität
 sowie für Speicherlösungen und deren Management. Dazu kennen die Teilnehmer:innen Architekturmuster für Data-Engineering-Pipelines und ETL-Prozesse.
@@ -44,6 +44,11 @@ Die Teilnehmer:innen kennen verschiedene Möglichkeiten zur Speicherung der Date
 * Relationale und NoSQL-Datenbanken
 * Data Warehouses
 * Data Lakes
+
+[[LZ-4-8]]
+==== LZ 4-8: Data Products, Data Contracts und Verantwortlichkeiten in Datenarchitekturen für KI-Systeme einordnen und für robuste Schnittstellen zwischen Fachlichkeit, Datenplattform und KI-Komponenten nutzen.
+
+Die Teilnehmer:innen kennen grundlegende Konzepte moderner Datenarchitekturen für KI-Systeme und verstehen die Rolle von Data Products, Data Contracts sowie fachlicher und technischer Verantwortlichkeiten für stabile und skalierbare Datenflüsse.
 
 // end::DE[]
 

--- a/docs/04-module-block-4/02-learning-goals.adoc
+++ b/docs/04-module-block-4/02-learning-goals.adoc
@@ -16,8 +16,8 @@ Die Teilnehmer:innen kennen relevante Werkzeuge fürs Daten-Labeln wie beispiels
 Die Teilnehmer:innen können gängige Plattformen für öffentlich zugängliche Daten nennen.
 
 
-[[LZ-4-4]]
-==== LZ 4-4: Datenpipelines und Datenarchitekturen für KI-Systeme so entwerfen, dass Qualität, Nachvollziehbarkeit, Skalierbarkeit, Governance und Wiederverwendbarkeit unterstützt werden.
+[[LZ-4-3]]
+==== LZ 4-3: Datenpipelines und Datenarchitekturen für KI-Systeme so entwerfen, dass Qualität, Nachvollziehbarkeit, Skalierbarkeit, Governance und Wiederverwendbarkeit unterstützt werden.
 
 Die Teilnehmer:innen haben ein Verständnis für die Gestaltung effizienter Datenpipelines und -architekturen, die Betrachtung von Datenqualität
 sowie für Speicherlösungen und deren Management. Dazu kennen die Teilnehmer:innen:
@@ -28,14 +28,14 @@ sowie für Speicherlösungen und deren Management. Dazu kennen die Teilnehmer:in
 [OPTIONAL]
 Die Teilnehmer:innen überblicken relevante Werkzeuge für Data Engineering Pipelines wie beispielsweise Apache Spark und Flink.
 
-[[LZ-4-5]]
-==== LZ 4-5: Strategien für Datenaggregation, -bereinigung, -transformation, -anreicherung und -augmentierung kennen
+[[LZ-4-4]]
+==== LZ 4-4: Strategien für Datenaggregation, -bereinigung, -transformation, -anreicherung und -augmentierung kennen
 
 Die Teilnehmer:innen kennen Strategien für Datenaggregation, -bereinigung, -transformation, -anreicherung und -augmentierung.
 
 
-[[LZ-4-7]]
-==== LZ 4-7: Möglichkeiten zur Speicherung der Daten kennen
+[[LZ-4-5]]
+==== LZ 4-5: Möglichkeiten zur Speicherung der Daten kennen
 
 Die Teilnehmer:innen kennen verschiedene Möglichkeiten zur Speicherung der Daten sowie deren Vor- und Nachteile. Zu den Möglichkeiten gehören die folgenden Technologien:
 
@@ -47,8 +47,8 @@ Die Teilnehmer:innen kennen verschiedene Möglichkeiten zur Speicherung der Date
 * Vektordatenbanken
 * Graphdatenbanken
 
-[[LZ-4-8]]
-==== LZ 4-8: Data Products, Data Contracts und Verantwortlichkeiten in Datenarchitekturen für KI-Systeme einordnen und für robuste Schnittstellen zwischen Fachlichkeit, Datenplattform und KI-Komponenten nutzen.
+[[LZ-4-6]]
+==== LZ 4-6: Data Products, Data Contracts und Verantwortlichkeiten in Datenarchitekturen für KI-Systeme einordnen und für robuste Schnittstellen zwischen Fachlichkeit, Datenplattform und KI-Komponenten nutzen.
 
 Die Teilnehmer:innen kennen grundlegende Konzepte moderner Datenarchitekturen für KI-Systeme und verstehen die Rolle von Data Products, Data Contracts sowie fachlicher und technischer Verantwortlichkeiten für stabile und skalierbare Datenflüsse.
 

--- a/docs/04-module-block-4/references.adoc
+++ b/docs/04-module-block-4/references.adoc
@@ -1,7 +1,7 @@
 === {references}
 
-<<sarkis>>, <<serra>>, <<dehghani>>, <<reis>>, <<bornstein>>,
-<<ford>>, <<bhajaria>>, <<sanderson>>, <<jones>>
+<<bhajaria>>, <<bornstein>>, <<dehghani>>, <<ford>>, <<gharbi>>, <<jones>>,
+<<reis>>, <<sanderson>>, <<sarkis>>, <<serra>>
 
 // tag::DE[]
 // end::DE[]

--- a/docs/05-module-block-5/02-learning-goals.adoc
+++ b/docs/05-module-block-5/02-learning-goals.adoc
@@ -41,7 +41,7 @@ Die Teilnehmer:innen kennen den Begriff MLOps für die Automatisierung des Life-
 Die Teilnehmer:innen haben ein Verständnis vom Tracking im Modelltraining, Parametern, Metriken und Ergebnissen.
 
 [[LZ-5-7]]
-==== LZ 5-7: ML-Modelle und darauf aufbauenden KI-Systeme evaluieren
+==== LZ 5-7: Modellevaluation, Systemevaluation und fachliche Nutzenbewertung unterscheiden und geeignete Evaluationsansätze für KI-Systeme auswählen.
 
 Die Teilnehmer:innen überblicken Ansätze zur Evaluation von ML-Modellen und darauf aufbauenden KI-Systemen.
 
@@ -95,7 +95,7 @@ Die Teilnehmer:innen überblicken bekannte SaaS-KI-Lösungen, wie beispielsweise
 Die Teilnehmer:innen kennen verschiedene Möglichkeiten und Standards für Embedded Deployments von ML-Modellen.
 
 [[LZ-5-16]]
-==== LZ 5-16: Monitoring im Hinblick auf KI-spezifische Anforderungen verstehen
+==== LZ 5-16: Monitoring und Observability für KI-Systeme konzipieren, insbesondere für Drift, Qualitätsverlust, Kosten, Latenz, Sicherheitsereignisse und Governance-relevante Nachweise.
 
 Die Teilnehmer:innen verstehen die Notwendigkeit für Monitoring, auch im Hinblick auf KI-spezifische Anforderungen wie das Tracking von Drift.
 
@@ -124,12 +124,12 @@ Die Teilnehmer:innen kennen verschiedene Methoden zur Nutzung von Feedback für 
 Die Teilnehmer:innen erfahren anhand eines Praxisbeispiels, wie eine MLOps-Pipeline aussehen kann und welche Einsichten diese auf die Parameter, Metriken usw. bietet.
 
 [[LZ-5-21]]
-==== LZ 5-21: [OPTIONAL] Build vs. Buy Entscheidungen für MLOps Systeme/Komponenten treffen
+==== LZ 5-21: Build-vs.-Buy-Entscheidungen für MLOps- und KI-Plattform-Komponenten anhand von Qualitätsanforderungen, Kosten, Risiko, Compliance und Integrationsaufwand treffen.
 
 Die Teilnehmer:innen sind in der Lage, Build vs. Buy Entscheidungen für MLOps Systeme/Komponenten zu treffen.
 
 [[LZ-5-22]]
-==== LZ 5-22: [OPTIONAL] MLOps-Werkzeuge und End-to-End Plattformen kennen
+==== LZ 5-22: [OPTIONAL] Klassen von MLOps-Werkzeugen und Plattformen sowie wesentliche Auswahlkriterien für ihren Einsatz kennen.
 
 Die Teilnehmer:innen kennen bekannte MLOps-Werkzeuge und End-to-End Plattformen,wie beispielsweise:
 

--- a/docs/05-module-block-5/02-learning-goals.adoc
+++ b/docs/05-module-block-5/02-learning-goals.adoc
@@ -95,13 +95,11 @@ als auch ML-spezifische wie beispielsweise MLflow.
 [[LZ-5-18]]
 ==== LZ 5-18: Nutzer-Feedback sowie Methoden und Werkzeuge zur Sammlung von Nutzer-Feedback verstehen
 
-Die Teilnehmer:innen verstehen den Nutzen von Nutzer-Feedback für das weitere Modelltraining. Darüber hinaus kennen die Teilnehmer:innen verschiedene Methoden und Werkzeuge zur Sammlung von Nutzer-Feedback, wie beispielsweise die Auswahl zwischen mehreren Antworten und Flagging in Gradio.
+Die Teilnehmer:innen verstehen den Nutzen von Nutzer-Feedback für das weitere Modelltraining.
+Darüber hinaus kennen die Teilnehmer:innen verschiedene Methoden und Werkzeuge zur Sammlung von Nutzer-Feedback, wie beispielsweise die Auswahl zwischen mehreren Antworten oder Flagging in Gradio.
 
-
-[[LZ-5-19]]
-==== LZ 5-19: [OPTIONAL] Methoden zur Nutzung von Feedback für das Modell-Training kennen
-
-Die Teilnehmer:innen kennen verschiedene Methoden zur Nutzung von Feedback für das Modell-Training, wie beispielsweise RLHF, RLAIF und DPO.
+[OPTIONAL]
+Die Teilnehmer:innen kennen weitere Methoden zur Gewinnung von Nutzer-Feedback, wie beispielsweise RLHF, RLAIF und DPO.
 
 
 [[LZ-5-22]]

--- a/docs/05-module-block-5/02-learning-goals.adoc
+++ b/docs/05-module-block-5/02-learning-goals.adoc
@@ -72,8 +72,8 @@ Die Teilnehmer:innen kennen eine Auswahl verschiedener Deployment-Möglichkeiten
 Die Teilnehmer:innen kennen gängige Plattformen und Werkzeuge für die Modellbereitstellung sowie Erstellung von POCs und verstehen die konzeptionelle Funktionsweise.
 
 
-[[LZ-5-13]]
-==== LZ 5-13: Vor- und Nachteile von SaaS und Self-Hosting nennen sowie Make-or-Buy-Entscheidungen anhand von Qualitätsanforderungen treffen
+[[LZ-5-10]]
+==== LZ 5-10: Vor- und Nachteile von SaaS und Self-Hosting nennen sowie Make-or-Buy-Entscheidungen anhand von Qualitätsanforderungen treffen
 
 Die Teilnehmer:innen kennen die Vor- und Nachteile von SaaS und Self-Hosting und können dazwischen abwägen.
 
@@ -82,8 +82,8 @@ Die Teilnehmer:innen sind in der Lage, Make-or-Buy Entscheidungen für MLOps- un
 [OPTIONAL]
 Die Teilnehmer:innen überblicken bekannte SaaS-KI-Lösungen, wie beispielsweise Azure OpenAI Services.
 
-[[LZ-5-16]]
-==== LZ 5-16: Monitoring und Observability für KI-Systeme konzipieren, insbesondere für Drift, Qualitätsverlust, Kosten, Latenz, Sicherheitsereignisse und Governance-relevante Nachweise.
+[[LZ-5-11]]
+==== LZ 5-11: Monitoring und Observability für KI-Systeme konzipieren, insbesondere für Drift, Qualitätsverlust, Kosten, Latenz, Sicherheitsereignisse und Governance-relevante Nachweise.
 
 Die Teilnehmer:innen verstehen die Notwendigkeit für Monitoring, auch im Hinblick auf KI-spezifische Anforderungen wie das Tracking von Drift.
 
@@ -92,8 +92,8 @@ Die Teilnehmer:innen kennen relevante Metriken wie beispielsweise Accuracy, Prec
 Die Teilnehmer:innen kennen Beispiel-Werkzeuge für Monitoring. Dies betrifft sowohl allgemeine Werkzeuge, wie beispielsweise Prometheus & Grafana,
 als auch ML-spezifische wie beispielsweise MLflow.
 
-[[LZ-5-18]]
-==== LZ 5-18: Nutzer-Feedback sowie Methoden und Werkzeuge zur Sammlung von Nutzer-Feedback verstehen
+[[LZ-5-12]]
+==== LZ 5-12: Nutzer-Feedback sowie Methoden und Werkzeuge zur Sammlung von Nutzer-Feedback verstehen
 
 Die Teilnehmer:innen verstehen den Nutzen von Nutzer-Feedback für das weitere Modelltraining.
 Darüber hinaus kennen die Teilnehmer:innen verschiedene Methoden und Werkzeuge zur Sammlung von Nutzer-Feedback, wie beispielsweise die Auswahl zwischen mehreren Antworten oder Flagging in Gradio.
@@ -102,8 +102,8 @@ Darüber hinaus kennen die Teilnehmer:innen verschiedene Methoden und Werkzeuge 
 Die Teilnehmer:innen kennen weitere Methoden zur Gewinnung von Nutzer-Feedback, wie beispielsweise RLHF, RLAIF und DPO.
 
 
-[[LZ-5-22]]
-==== LZ 5-22: [OPTIONAL] Klassen von MLOps-Werkzeugen und Plattformen sowie wesentliche Auswahlkriterien für ihren Einsatz kennen.
+[[LZ-5-13]]
+==== LZ 5-13: [OPTIONAL] Klassen von MLOps-Werkzeugen und Plattformen sowie wesentliche Auswahlkriterien für ihren Einsatz kennen.
 
 Die Teilnehmer:innen kennen bekannte MLOps-Werkzeuge und End-to-End Plattformen,wie beispielsweise:
 

--- a/docs/05-module-block-5/02-learning-goals.adoc
+++ b/docs/05-module-block-5/02-learning-goals.adoc
@@ -58,18 +58,7 @@ Die Teilnehmer:innen kennen verschiedene Arten von Drift, wie beispielsweise Dat
 
 Die Teilnehmer:innen haben ein Verständnis von CI/CD-Pipelines, Modellmanagement und Deployment-Strategien für KI-Modelle.
 
-[[LZ-5-10]]
-==== LZ 5-10: [OPTIONAL] Plattformen für die Modellbereitstellung kennen
-
-Die Teilnehmer:innen kennen gängige Plattformen für die Modellbereitstellung, wie beispielsweise Huggingface Hub.
-
-Die Teilnehmer:innen können gängige Werkzeuge für das Erstellen von POCs von KI-Systemen, wie beispielsweise Gradio, nennen und verstehen die konzeptionelle Funktionsweise.
-
-
-[[LZ-5-12]]
-==== LZ 5-12: Deployment-Möglichkeiten von KI-Modellen kennen
-
-Die Teilnehmer:innen kennen verschiedene Deployment-Möglichkeiten von KI-Modellen. Eine Auswahl der folgenden Möglichkeiten verstehen die Teilnehmer:innen:
+Die Teilnehmer:innen kennen eine Auswahl verschiedener Deployment-Möglichkeiten von KI-Modellen:
 
 * API Deployment
 * Embedded Deployment
@@ -78,6 +67,10 @@ Die Teilnehmer:innen kennen verschiedene Deployment-Möglichkeiten von KI-Modell
 * Containerization
 * Serverless Deployment
 * Cloud Services
+
+[OPTIONAL]
+Die Teilnehmer:innen kennen gängige Plattformen und Werkzeuge für die Modellbereitstellung sowie Erstellung von POCs und verstehen die konzeptionelle Funktionsweise.
+
 
 [[LZ-5-13]]
 ==== LZ 5-13: Vor- und Nachteile von SaaS und Self-Hosting nennen

--- a/docs/05-module-block-5/02-learning-goals.adoc
+++ b/docs/05-module-block-5/02-learning-goals.adoc
@@ -122,46 +122,49 @@ Die Teilnehmer:innen kennen bekannte MLOps-Werkzeuge und End-to-End Plattformen,
 [[LG-5-1]]
 ==== LG 5-1: Know (hardware) requirements for training and inference
 
-The participants know the different (hardware) requirements for TPU, GPU or CPU for training and inference, for example.
+Participants know the different (hardware) requirements for training and inference, for example for TPUs, NPUs, LPUs, GPUs, or CPUs.
 
 [[LG-5-2]]
 ==== LG 5-2: Know the trade-offs of different model architectures with regard to quality characteristics
-Participants will be able to name examples of trade-offs between different model architectures with regard to quality characteristics. In particular for scaling, efficiency and storage load, participants should know the trade-offs as well as the advantages and disadvantages of important architectures such as RNNs and transformers.
+Participants can give examples of trade-offs between different model architectures with regard to quality characteristics. Particularly for scaling, efficiency, and memory footprint, participants should know the trade-offs as well as the advantages and disadvantages of important architectures such as RNNs and transformers.
 
 [[LG-5-3]]
 ==== LG 5-3: Adjust different quality features of an ML model
 
-Participants will be familiar with ways to adjust various quality characteristics such as accuracy, efficiency and storage load of an ML model and to trade them off against each other. In particular, the participants know the following techniques:
+Participants know ways to balance and trade off different quality characteristics of an ML model, such as accuracy, efficiency, and memory footprint. In particular, they know the following techniques:
 
-- Quantization
-- Pruning
-- Distillation
-- LoRA
+* Quantization
+* Pruning
+* Distillation
+* LoRA
 
 
 
 [[LG-5-4]]
-==== LG 5-4: Understanding the costs, power consumption and sustainable use of AI (Green IT)
+==== LG 5-4: Understand the costs, power consumption, and sustainable use of AI (Green IT)
 
-Participants gain an understanding of the costs, power consumption and sustainable use of AI (green IT). In particular, participants will know how to develop AI models and systems that work in a resource-efficient manner by using memory, computing power and storage space efficiently.
+Participants gain an understanding of the costs, power consumption, and sustainable use of AI (Green IT). In particular, they know how to develop AI models and systems that operate efficiently by making economical use of memory, compute capacity, and storage space.
 
 
 [[LG-5-5]]
-==== LG 5-5: Know (hardware) requirements for training and inference
+==== LG 5-5: Gain an overview of MLOps for automating the life cycle of a data science project
 
-The participants know the term MLOps for the automation of the life cycle of a data science project and the connection with DevOps.
+Participants know the term MLOps for automating the life cycle of a data science project and its relationship to DevOps.
+
+[OPTIONAL]
+Using a practical example, participants understand what an MLOps pipeline can look like and what insights it provides into parameters, metrics, and other aspects.
 
 
 [[LG-5-6]]
-==== LG 5-6: Model training, parameters, metrics and results tracking
+==== LG 5-6: Track model training, parameters, metrics, and results
 
-The participants have an understanding of tracking in model training, parameters, metrics and results.
+Participants understand tracking in model training, including parameters, metrics, and results.
 
 
 [[LG-5-7]]
-==== LG 5-7: Evaluate ML models and AI systems based on them
+==== LG 5-7: Distinguish model evaluation, system evaluation, and assessment of business value, and select suitable evaluation approaches for AI systems
 
-Participants will gain an overview of approaches for evaluating ML models and AI systems based on them.
+Participants have an overview of approaches for evaluating ML models and the AI systems based on them.
 
 
 [[LG-5-8]]
@@ -171,98 +174,62 @@ Participants are familiar with different types of drift, such as data drift or m
 
 
 [[LG-5-9]]
-==== LG 5-9: Overview of CI/CD pipelines, model management and deployment strategies for AI models
+==== LG 5-9: Gain an overview of CI/CD pipelines, model management, and deployment strategies for AI models
 
-Participants will have an understanding of CI/CD pipelines, model management and deployment strategies for AI models.
+Participants understand CI/CD pipelines, model management, and deployment strategies for AI models.
+
+Participants know a selection of different deployment options for AI models:
+
+* API deployment
+* Embedded deployment
+* Batch prediction
+* Streaming
+* Containerization
+* Serverless deployment
+* Cloud services
+
+[OPTIONAL]
+Participants know common platforms and tools for model provision and for creating POCs and understand how they work conceptually.
 
 
 [[LG-5-10]]
-==== LG 5-10: Know platforms for model provision
+==== LG 5-10: State the advantages and disadvantages of SaaS and self-hosting and make make-or-buy decisions based on quality requirements
 
-The participants are familiar with common platforms for model provision, such as Huggingface Hub.
+Participants know the advantages and disadvantages of SaaS and self-hosting and can weigh them against each other.
+
+Participants can make make-or-buy decisions for MLOps and AI platform systems or components based on quality requirements, cost, risk, compliance, and integration effort.
+
+[OPTIONAL]
+Participants have an overview of well-known SaaS AI solutions, such as Azure OpenAI Services.
 
 
 [[LG-5-11]]
-==== LG 5-11: Classify tools for the creation of POCs of AI systems
+==== LG 5-11: Design monitoring and observability for AI systems, particularly for drift, quality degradation, costs, latency, security events, and governance-relevant evidence
 
-Participants will be able to name common tools for creating POCs for AI systems, such as Gradio, and understand how they work conceptually.
+Participants understand the need for monitoring, including with regard to AI-specific requirements such as drift tracking.
+
+Participants know relevant metrics such as accuracy, precision, recall, F1 score, MAE, MSE, perplexity, latency, throughput, and resource utilization, and understand why they are relevant for monitoring.
+
+Participants know example monitoring tools. These include both general-purpose tools, such as Prometheus and Grafana, and ML-specific tools, such as MLflow.
+
 
 [[LG-5-12]]
-==== LG 5-12: Knowing the deployment options of AI models
+==== LG 5-12: Understand user feedback and methods and tools for collecting it
 
-Participants are familiar with various deployment options for AI models. Participants will understand a selection of the following options:
+Participants understand the benefits of user feedback for further model training. They also know various methods and tools for collecting user feedback, such as choosing between multiple answers or flagging in Gradio.
 
-- API Deployment
-- Embedded Deployment
-- Batch Prediction
-- Streaming
-- Containerization
-- Serverless Deployment
-- Cloud services
-
+[OPTIONAL]
+Participants know further methods for obtaining user feedback, such as RLHF, RLAIF, and DPO.
 
 
 [[LG-5-13]]
-==== LG 5-13: List advantages and disadvantages of SaaS and self-hosting
+==== LG 5-13: [OPTIONAL] Know classes of MLOps tools and platforms and essential criteria for selecting them
 
-The participants know the advantages and disadvantages of SaaS and self-hosting and can weigh up the pros and cons.
+Participants know well-known MLOps tools and end-to-end platforms, such as:
 
-
-[[LG-5-14]]
-==== LG 5-14: Overview of SaaS AI solutions
-
-Participants will gain an overview of well-known SaaS AI solutions, such as Azure OpenAI Services.
-
-
-[[LG-5-15]]
-==== LG 5-15: Know embedded deployments of ML models
-
-Participants will be familiar with various options and standards for embedded deployments of ML models.
-
-
-[[LG-5-16]]
-==== LG 5-16: Understanding monitoring with regard to AI-specific requirements
-
-The participants understand the need for monitoring, also with regard to AI-specific requirements such as drift tracking.
-Participants are familiar with relevant metrics such as accuracy, precision, recall and F1 score, MAE, MSE, perplexity, latency, throughput and resource utilization and understand why these are relevant for monitoring.
-
-[[LG-5-17]]
-==== LG 5-17: Overview of sample tools for monitoring
-
-The participants know example tools for monitoring. This includes both general tools, such as Prometheus & Grafana, as well as ML-specific tools, such as MLflow.
-
-
-[[LG-5-18]]
-==== LG 5-18: Understanding user feedback and methods and tools for collecting user feedback
-
-Participants understand the benefits of user feedback for further model training. In addition, participants are familiar with various methods and tools for collecting user feedback, such as choosing between multiple answers and flagging in Gradio.
-
-[[LG-5-19]]
-==== LG 5-19: Know methods for using feedback for model training
-
-Participants are familiar with various methods of using feedback for model training, such as RLHF, RLAIF and DPO.
-
-
-[[LG-5-20]]
-==== LG 5-20: [OPTIONAL] Understanding the MLOps pipeline using a practical example
-
-Using a practical example, participants will learn what an MLOps pipeline can look like and what insights it offers into parameters, metrics, etc.
-
-
-[[LG-5-21]]
-==== LG 5-21: [OPTIONAL] Make build vs. buy decisions for MLOps systems/components
-
-Participants will be able to make build vs. buy decisions for MLOps systems/components.
-
-
-[[LG-5-22]]
-==== LG 5-22: [OPTIONAL] Know MLOps tools and end-to-end platforms
-
-The participants are familiar with well-known MLOps tools and end-to-end platforms, such as:
-
-- Domino Data Lab, h2o.ai, DVC, activeloop, aporia, argo, arize, bentoML, comet ML, DagsHub, Databricks MLOps Stacks, Feast, Kedro, Kubeflow, Metaflow, MLflow, MLRun, prefect, PrimeHub, Weights & Biases, WhyLabs, zenML, KNIME, RapidMiner, NVIDIA AI Enterprise, watsonx.ai
-- OpenSource: MLFlow, Weights & Biases, ClearML
-- PaaS: AWS SageMaker, Azure ML.
+* Domino Data Lab, h2o.ai, DVC, activeloop, aporia, argo, arize, bentoML, comet ML, DagsHub, Databricks MLOps Stacks, Feast, Kedro, Metaflow, MLflow, MLRun, prefect, PrimeHub, Weights & Biases, WhyLabs, zenML, KNIME, RapidMiner, NVIDIA AI Enterprise, watsonx.ai
+* Open source: MLflow, Kubeflow, ClearML
+* PaaS: AWS SageMaker, Azure ML, Google Vertex AI
 
 
 

--- a/docs/05-module-block-5/02-learning-goals.adoc
+++ b/docs/05-module-block-5/02-learning-goals.adoc
@@ -35,6 +35,9 @@ Die Teilnehmer:innen erlangen ein Verständnis für Kosten, Stromverbrauch und n
 
 Die Teilnehmer:innen kennen den Begriff MLOps für die Automatisierung des Life-Cycles eines Data-Science-Projekts sowie den Zusammenhang mit DevOps.
 
+[OPTIONAL]
+Die Teilnehmer:innen verstehen anhand eines Praxisbeispiels, wie eine MLOps-Pipeline aussehen kann und welche Einsichten diese auf die Parameter, Metriken usw. bietet.
+
 [[LZ-5-6]]
 ==== LZ 5-6: Modelltraining, Parameter, Metriken und Ergebnisse tracken
 
@@ -108,10 +111,6 @@ Die Teilnehmer:innen verstehen den Nutzen von Nutzer-Feedback für das weitere M
 
 Die Teilnehmer:innen kennen verschiedene Methoden zur Nutzung von Feedback für das Modell-Training, wie beispielsweise RLHF, RLAIF und DPO.
 
-[[LZ-5-20]]
-==== LZ 5-20: [OPTIONAL] MLOps-Pipeline an einem Praxisbeispiel verstehen
-
-Die Teilnehmer:innen erfahren anhand eines Praxisbeispiels, wie eine MLOps-Pipeline aussehen kann und welche Einsichten diese auf die Parameter, Metriken usw. bietet.
 
 [[LZ-5-21]]
 ==== LZ 5-21: Build-vs.-Buy-Entscheidungen für MLOps- und KI-Plattform-Komponenten anhand von Qualitätsanforderungen, Kosten, Risiko, Compliance und Integrationsaufwand treffen.

--- a/docs/05-module-block-5/02-learning-goals.adoc
+++ b/docs/05-module-block-5/02-learning-goals.adoc
@@ -115,9 +115,9 @@ Die Teilnehmer:innen sind in der Lage, Build vs. Buy Entscheidungen für MLOps S
 
 Die Teilnehmer:innen kennen bekannte MLOps-Werkzeuge und End-to-End Plattformen,wie beispielsweise:
 
-* Domino Data Lab, h2o.ai, DVC, activeloop, aporia, argo, arize, bentoML, comet ML, DagsHub, Databricks MLOps Stacks, Feast, Kedro, Kubeflow, Metaflow, MLflow, MLRun, prefect, PrimeHub, Weights & Biases, WhyLabs, zenML, KNIME, RapidMiner, NVIDIA AI Enterprise, watsonx.ai
-* OpenSource: MLFlow, Weights & Biases, ClearML
-* PaaS: AWS SageMaker, Azure ML.
+* Domino Data Lab, h2o.ai, DVC, activeloop, aporia, argo, arize, bentoML, comet ML, DagsHub, Databricks MLOps Stacks, Feast, Kedro, Metaflow, MLflow, MLRun, prefect, PrimeHub, Weights & Biases, WhyLabs, zenML, KNIME, RapidMiner, NVIDIA AI Enterprise, watsonx.ai
+* OpenSource: MLFlow, Kubeflow, ClearML
+* PaaS: AWS SageMaker, Azure ML, Google Vertex AI
 
 // end::DE[]
 

--- a/docs/05-module-block-5/02-learning-goals.adoc
+++ b/docs/05-module-block-5/02-learning-goals.adoc
@@ -73,15 +73,14 @@ Die Teilnehmer:innen kennen gängige Plattformen und Werkzeuge für die Modellbe
 
 
 [[LZ-5-13]]
-==== LZ 5-13: Vor- und Nachteile von SaaS und Self-Hosting nennen
+==== LZ 5-13: Vor- und Nachteile von SaaS und Self-Hosting nennen sowie Make-or-Buy-Entscheidungen anhand von Qualitätsanforderungen treffen
 
 Die Teilnehmer:innen kennen die Vor- und Nachteile von SaaS und Self-Hosting und können dazwischen abwägen.
 
-[[LZ-5-14]]
-==== LZ 5-14: SaaS-KI-Lösungen überblicken
+Die Teilnehmer:innen sind in der Lage, Make-or-Buy Entscheidungen für MLOps- und KI-Plattform Systemen/Komponenten anhand von Qualitätsanforderungen, Kosten, Risiko, Compliance und Integrationsaufwand zu treffen.
 
+[OPTIONAL]
 Die Teilnehmer:innen überblicken bekannte SaaS-KI-Lösungen, wie beispielsweise Azure OpenAI Services.
-
 
 [[LZ-5-16]]
 ==== LZ 5-16: Monitoring und Observability für KI-Systeme konzipieren, insbesondere für Drift, Qualitätsverlust, Kosten, Latenz, Sicherheitsereignisse und Governance-relevante Nachweise.
@@ -104,11 +103,6 @@ Die Teilnehmer:innen verstehen den Nutzen von Nutzer-Feedback für das weitere M
 
 Die Teilnehmer:innen kennen verschiedene Methoden zur Nutzung von Feedback für das Modell-Training, wie beispielsweise RLHF, RLAIF und DPO.
 
-
-[[LZ-5-21]]
-==== LZ 5-21: Build-vs.-Buy-Entscheidungen für MLOps- und KI-Plattform-Komponenten anhand von Qualitätsanforderungen, Kosten, Risiko, Compliance und Integrationsaufwand treffen.
-
-Die Teilnehmer:innen sind in der Lage, Build vs. Buy Entscheidungen für MLOps Systeme/Komponenten zu treffen.
 
 [[LZ-5-22]]
 ==== LZ 5-22: [OPTIONAL] Klassen von MLOps-Werkzeugen und Plattformen sowie wesentliche Auswahlkriterien für ihren Einsatz kennen.

--- a/docs/05-module-block-5/references.adoc
+++ b/docs/05-module-block-5/references.adoc
@@ -1,7 +1,7 @@
 === {references}
 
-<<chen>>, <<treveil>>, <<haviv>>, <<osipov>>,
-<<tanweihao>>, <<wilson>>, <<salama>>, <<kumara>>
+<<chen>>, <<gharbi>>, <<haviv>>, <<kumara>>, <<osipov>>, <<salama>>,
+<<tanweihao>>, <<treveil>>, <<wilson>>
 
 // tag::DE[]
 // end::DE[]

--- a/docs/06-module-block-6/02-learning-goals.adoc
+++ b/docs/06-module-block-6/02-learning-goals.adoc
@@ -24,11 +24,6 @@ um die Art und den Grad der Integration von KI-Systemen zu bestimmen und zu doku
 [OPTIONAL]
 Die Teilnehmer:innen üben und diskutieren anhand eines Fallbeispiels mit einer ausgedachten Fachlichkeit, Integrationsoptionen für KI in eine bestehende Software-Landschaft abzuwägen.
 
-[[LZ-6-5]]
-==== LZ 6-5: [OPTIONAL] Frameworks und Ansätze zur Evaluation von GenAI- und LLM-basierten Systemen einordnen und passend auswählen.
-
-Die Teilnehmer:innen kennen gängige Evaluations-Frameworks wie beispielsweise LangSmith oder LangFuse, um mit Unbestimmtheit und Fehlern in KI-Systemen umzugehen.
-
 
 [[LZ-6-7]]
 ==== LZ 6-7: Generative KI und ihre Funktionsweise grundlegend verstehen
@@ -108,6 +103,9 @@ Die Teilnehmer:innen kennen mehrere Techniken zur Evaluation von LLM-Anwendungen
 * Human Feedback
 * Comparative Evaluation
 * Model Based Evaluation
+
+[OPTIONAL]
+Die Teilnehmer:innen kennen gängige Evaluations-Frameworks wie beispielsweise LangSmith oder LangFuse, um mit Unbestimmtheit und Fehlern in KI-Systemen umzugehen.
 
 [[LZ-6-16]]
 ==== LZ 6-16: Bekannte LLMs und Auswahlkriterien überblicken

--- a/docs/06-module-block-6/02-learning-goals.adoc
+++ b/docs/06-module-block-6/02-learning-goals.adoc
@@ -21,17 +21,14 @@ Die Teilnehmer:innen kennen Möglichkeiten, KI-Systeme in IT-Landschaften auf st
 können sie das strategische Design von DDD (insbesondere Context Maps) einsetzen,
 um die Art und den Grad der Integration von KI-Systemen zu bestimmen und zu dokumentieren.
 
+[OPTIONAL]
+Die Teilnehmer:innen üben und diskutieren anhand eines Fallbeispiels mit einer ausgedachten Fachlichkeit, Integrationsoptionen für KI in eine bestehende Software-Landschaft abzuwägen.
 
 [[LZ-6-5]]
 ==== LZ 6-5: [OPTIONAL] Frameworks und Ansätze zur Evaluation von GenAI- und LLM-basierten Systemen einordnen und passend auswählen.
 
 Die Teilnehmer:innen kennen gängige Evaluations-Frameworks wie beispielsweise LangSmith oder LangFuse, um mit Unbestimmtheit und Fehlern in KI-Systemen umzugehen.
 
-
-[[LZ-6-6]]
-==== LZ 6-6: [OPTIONAL] Fallbeispiel mit einer ausgedachten Fachlichkeit diskutieren
-
-Die Teilnehmer:innen üben und diskutieren anhand eines Fallbeispiels mit einer ausgedachten Fachlichkeit, Integrationsoptionen für KI in eine bestehende Software-Landschaft abzuwägen.
 
 [[LZ-6-7]]
 ==== LZ 6-7: Generative KI und ihre Funktionsweise grundlegend verstehen

--- a/docs/06-module-block-6/02-learning-goals.adoc
+++ b/docs/06-module-block-6/02-learning-goals.adoc
@@ -50,14 +50,11 @@ Die Teilnehmer:innen kennen bekannte Patterns bei der Nutzung von LLMs. Dies umf
 * Agenten
 
 [[LZ-6-10]]
-==== LZ 6-10: Use-Cases für RAG (Retrieval-Augmented Generation) kennen
+==== LZ 6-10: Use-Cases für RAG (Retrieval-Augmented Generation) sowie ausgewählte RAG-Techniken kennen und verstehen
 
 Die Teilnehmer:innen kennen typische Use-Cases für RAG wie beispielsweise „Talk to your documents/database/API“.
 
-[[LZ-6-11]]
-==== LZ 6-11: Ausgewählte RAG-Techniken kennen und verstehen
-
-Die Teilnehmer:innen kennen eine Auswahl der gängigen RAG-Techniken wie beispielsweise:
+Insbesondere kennen die Teilnehmer:innen kennen eine Auswahl der gängigen RAG-Techniken wie beispielsweise:
 
 * Reguläres RAG, GraphRAG, CAG, Agentic RAG and Multi-Agent RAG
 * Context Enrichment Techniques
@@ -68,6 +65,7 @@ Die Teilnehmer:innen kennen eine Auswahl der gängigen RAG-Techniken wie beispie
 * Iterative Retrieval
 * Ensemble Retrieval
 * Knowledge Graph Integration
+
 
 [[LZ-6-12]]
 ==== LZ 6-12: Arten von Prompt Engineering kennen

--- a/docs/06-module-block-6/02-learning-goals.adoc
+++ b/docs/06-module-block-6/02-learning-goals.adoc
@@ -38,7 +38,7 @@ Die Teilnehmer:innen verstehen die Qualitätsmerkmale, die für KI-Systeme beson
 * Interpretierbarkeit
 
 [[LZ-6-5]]
-==== LZ 6-5: [OPTIONAL] Evaluations-Frameworks für KI-Systeme kennen
+==== LZ 6-5: [OPTIONAL] Frameworks und Ansätze zur Evaluation von GenAI- und LLM-basierten Systemen einordnen und passend auswählen.
 
 Die Teilnehmer:innen kennen gängige Evaluations-Frameworks wie beispielsweise LangSmith oder LangFuse, um mit Unbestimmtheit und Fehlern in KI-Systemen umzugehen.
 
@@ -59,7 +59,7 @@ Die Teilnehmer:innen haben ein grundlegendes Verständnis von generativer KI wie
 Die Teilnehmer:innen verstehen die Funktionsweise von LLMs und können die zugehörige Begriffswelteinordnen: Token, Embedding, RNN, Transformer, Attention.
 
 [[LZ-6-9]]
-==== LZ 6-9: Bekannte Patterns bei der Nutzung von LLMs kennen
+==== LZ 6-9: Architekturmuster für den Einsatz von LLMs kennen und deren Einsatzgrenzen, Risiken und Trade-offs bewerten, insbesondere bei RAG, Function Calling, Fine-Tuning, Assistenzsystemen und Agenten.
 
 Die Teilnehmer:innen kennen bekannte Patterns bei der Nutzung von LLMs. Dies umfasst die folgenden Patterns:
 * RAG und Retrieval-Strategien
@@ -100,7 +100,7 @@ Die Teilnehmer:innen kennen verschiedene Arten von Prompt Engineering, wie beisp
 sowie allgemeine Best Practices für das Prompting.
 
 [[LZ-6-13]]
-==== LZ 6-13: Agentic Workflows überblicken
+==== LZ 6-13: Agentic Workflows hinsichtlich Planung, Werkzeugnutzung, Reflexion, Zustandsmanagement, Kontrollmechanismen und Multi-Agenten-Kollaboration analysieren und architektonisch einordnen.
 
 Die Teilnehmer:innen wissen, was Agentic Workflows sind und kennen die Begriffe Reflexion, Werkzeugnutzung, Planung und Multi-Agenten-Kollaboration.
 
@@ -121,7 +121,7 @@ Die Teilnehmer:innen wissen welche Design Patterns für Generative KI-Systeme ex
 * Red and Blue Team Dual-Model Evaluation
 
 [[LZ-6-15]]
-==== LZ 6-15: Techniken zur Evaluation von LLM-Anwendungen kennen
+==== LZ 6-15: Techniken zur Evaluation von LLM-Anwendungen auswählen und auf Antwortqualität, Retrieval-Qualität, Halluzinationen, Sicherheit, Kosten und Nutzermehrwert anwenden.
 
 Die Teilnehmer:innen kennen mehrere Techniken zur Evaluation von LLM-Anwendungen. Dies können beispielsweise die folgenden Techniken sein:
 
@@ -142,15 +142,28 @@ Die Teilnehmer:innen kennen bekannte LLMs wie beispielsweise GPT, Claude, Gemini
 Die Teilnehmer:innen verstehen die Bedeutung von Cost Management für GenAI Applikationen.
 
 [[LZ-6-18]]
-==== LZ 6-18: Beispiele von verbreiteten Bibliotheken, Schnittstellen und Tools im Zusammenhang mit LLM-Anwendungen nennen
+==== LZ 6-18: Klassen von Bibliotheken, Schnittstellen und Werkzeugen für LLM-Anwendungen sowie deren Einsatzkontexte und Auswahlkriterien kennen.
 
 Die Teilnehmer:innen kennen einige Beispiele von verbreiteten Bibliotheken, Schnittstellen und Tools im Zusammenhang
 mit LLM-Anwendungen wie beispielsweise OpenAI-API oder LangChain.
 
 [[LZ-6-19]]
-==== LZ 6-19: [OPTIONAL] Agentic AI Software Architekturen, AI Agent Architekturkomponenten und Typen von AI Agentarchitekturen kennen
+==== LZ 6-19: [OPTIONAL] Agentic-AI-Architekturen, zentrale Architekturkomponenten, Sicherheits- und Governance-Grenzen sowie typische Einsatzmuster und Grenzen von Agentensystemen kennen und bewerten.
 
 Die Teilnehmer:innen kennen Agentic AI Software Architekturen, AI Agent Architekturkomponenten, Typen von AI Agentarchitekturen.
+
+[[LZ 6-20]]
+==== LZ 6-20: Harness Engineering für LLM- und Agentensysteme architektonisch einordnen und anwenden
+
+Die Teilnehmer:innen verstehen Harness Engineering als architektonische Kontroll- und Integrationsschicht für probabilistische KI-Komponenten wie LLMs und Agenten. Sie können Harness-Ansätze mit klassischen Architekturkonzepten wie Kapselung, Schnittstellenkontrolle, Invarianten, Betriebsgrenzen, Observability, Policy Enforcement, Fehlerisolierung, kontrollierter Änderung, Governance und Auditierbarkeit beschreiben und beim Entwurf produktionsfähiger KI-Systeme anwenden.
+Sie können insbesondere ableiten, wie ein Harness:
+•	die Autonomie einer KI-Komponente durch klare Schnittstellen, erlaubte Aktionen und Betriebsgrenzen begrenzt,
+•	Eingaben, Kontext, Toolzugriffe, Zustände und Ausgaben kontrolliert,
+•	Systeminvarianten und Policies durchsetzt,
+•	Fehler und unsichere Modelloutputs isoliert,
+•	Beobachtbarkeit, Nachvollziehbarkeit und Auditierbarkeit sicherstellt,
+•	kontrollierte Änderungen an Prompts, Modellen, Retrieval-Komponenten und Tools ermöglicht,
+•	Sicheren Betrieb sowie die sichere Weiterentwicklung von KI-Systemen unterstützt.
 
 // end::DE[]
 

--- a/docs/06-module-block-6/02-learning-goals.adoc
+++ b/docs/06-module-block-6/02-learning-goals.adoc
@@ -14,8 +14,8 @@ Die Teilnehmer:innen kennen verschiedene Integrationsebenen von KI. Dazu gehöre
 
 Die Teilnehmer:innen kennen einige Beispiele von verbreiteten Bibliotheken, Schnittstellen und Tools zur Integration von KI-Modellen.
 
-[[LZ-6-3]]
-==== LZ 6-3: KI-Systeme in die Gesamtarchitektur einer IT-Landschaft integrieren
+[[LZ-6-2]]
+==== LZ 6-2: KI-Systeme in die Gesamtarchitektur einer IT-Landschaft integrieren
 
 Die Teilnehmer:innen kennen Möglichkeiten, KI-Systeme in IT-Landschaften auf strategischer Ebene zu integrieren. Beispielsweise
 können sie das strategische Design von DDD (insbesondere Context Maps) einsetzen,
@@ -25,16 +25,16 @@ um die Art und den Grad der Integration von KI-Systemen zu bestimmen und zu doku
 Die Teilnehmer:innen üben und diskutieren anhand eines Fallbeispiels mit einer ausgedachten Fachlichkeit, Integrationsoptionen für KI in eine bestehende Software-Landschaft abzuwägen.
 
 
-[[LZ-6-7]]
-==== LZ 6-7: Generative KI und ihre Funktionsweise grundlegend verstehen
+[[LZ-6-3]]
+==== LZ 6-3: Generative KI und ihre Funktionsweise grundlegend verstehen
 
 Die Teilnehmer:innen haben ein grundlegendes Verständnis von generativer KI wie beispielsweise LLMs und Diffusionmodelle.
 
 Die Teilnehmer:innen verstehen die Funktionsweise von LLMs und können die zugehörige Begriffswelteinordnen: Token, Embedding, RNN, Transformer, Attention.
 
 
-[[LZ-6-9]]
-==== LZ 6-9: Architekturmuster für den Einsatz von LLMs kennen und deren Einsatzgrenzen, Risiken und Trade-offs bewerten, insbesondere bei RAG, Function Calling, Fine-Tuning, Assistenzsystemen und Agenten.
+[[LZ-6-4]]
+==== LZ 6-4: Architekturmuster für den Einsatz von LLMs kennen und deren Einsatzgrenzen, Risiken und Trade-offs bewerten, insbesondere bei RAG, Function Calling, Fine-Tuning, Assistenzsystemen und Agenten.
 
 Die Teilnehmer:innen kennen bekannte Patterns bei der Nutzung von LLMs. Dies umfasst die folgenden Patterns:
 
@@ -44,8 +44,8 @@ Die Teilnehmer:innen kennen bekannte Patterns bei der Nutzung von LLMs. Dies umf
 * Assistenten
 * Agenten
 
-[[LZ-6-10]]
-==== LZ 6-10: Use-Cases für RAG (Retrieval-Augmented Generation) sowie ausgewählte RAG-Techniken kennen und verstehen
+[[LZ-6-5]]
+==== LZ 6-5: Use-Cases für RAG (Retrieval-Augmented Generation) sowie ausgewählte RAG-Techniken kennen und verstehen
 
 Die Teilnehmer:innen kennen typische Use-Cases für RAG wie beispielsweise „Talk to your documents/database/API“.
 
@@ -62,8 +62,8 @@ Insbesondere kennen die Teilnehmer:innen kennen eine Auswahl der gängigen RAG-T
 * Knowledge Graph Integration
 
 
-[[LZ-6-12]]
-==== LZ 6-12: Arten von Prompt Engineering kennen
+[[LZ-6-6]]
+==== LZ 6-6: Arten von Prompt Engineering kennen
 
 Die Teilnehmer:innen kennen verschiedene Arten von Prompt Engineering, wie beispielsweise
 
@@ -73,13 +73,13 @@ Die Teilnehmer:innen kennen verschiedene Arten von Prompt Engineering, wie beisp
 
 sowie allgemeine Best Practices für das Prompting.
 
-[[LZ-6-13]]
-==== LZ 6-13: Agentic Workflows hinsichtlich Planung, Werkzeugnutzung, Reflexion, Zustandsmanagement, Kontrollmechanismen und Multi-Agenten-Kollaboration analysieren und architektonisch einordnen.
+[[LZ-6-7]]
+==== LZ 6-7: Agentic Workflows hinsichtlich Planung, Werkzeugnutzung, Reflexion, Zustandsmanagement, Kontrollmechanismen und Multi-Agenten-Kollaboration analysieren und architektonisch einordnen.
 
 Die Teilnehmer:innen wissen, was Agentic Workflows sind und kennen die Begriffe Reflexion, Werkzeugnutzung, Planung und Multi-Agenten-Kollaboration.
 
-[[LZ-6-14]]
-==== LZ 6-14: Eine Auswahl von Design Patterns für Generative KI-Systeme kennen
+[[LZ-6-8]]
+==== LZ 6-8: Eine Auswahl von Design Patterns für Generative KI-Systeme kennen
 
 Die Teilnehmer:innen wissen welche Design Patterns für Generative KI-Systeme existieren. Sie kennen eine Auswahl der folgenden Patterns:
 
@@ -94,8 +94,8 @@ Die Teilnehmer:innen wissen welche Design Patterns für Generative KI-Systeme ex
 * Memory Cognition for LLMs
 * Red and Blue Team Dual-Model Evaluation
 
-[[LZ-6-15]]
-==== LZ 6-15: Techniken zur Evaluation von LLM-Anwendungen auswählen und auf Antwortqualität, Retrieval-Qualität, Halluzinationen, Sicherheit, Kosten und Nutzermehrwert anwenden.
+[[LZ-6-9]]
+==== LZ 6-9: Techniken zur Evaluation von LLM-Anwendungen auswählen und auf Antwortqualität, Retrieval-Qualität, Halluzinationen, Sicherheit, Kosten und Nutzermehrwert anwenden.
 
 Die Teilnehmer:innen kennen mehrere Techniken zur Evaluation von LLM-Anwendungen. Dies können beispielsweise die folgenden Techniken sein:
 
@@ -107,30 +107,30 @@ Die Teilnehmer:innen kennen mehrere Techniken zur Evaluation von LLM-Anwendungen
 [OPTIONAL]
 Die Teilnehmer:innen kennen gängige Evaluations-Frameworks wie beispielsweise LangSmith oder LangFuse, um mit Unbestimmtheit und Fehlern in KI-Systemen umzugehen.
 
-[[LZ-6-16]]
-==== LZ 6-16: Bekannte LLMs und Auswahlkriterien überblicken
+[[LZ-6-10]]
+==== LZ 6-10: Bekannte LLMs und Auswahlkriterien überblicken
 
 Die Teilnehmer:innen kennen bekannte LLMs wie beispielsweise GPT, Claude, Gemini, Llama, Mistral oder Luminous, und Auswahlkriterien für ein geeignetes LLM.
 
 
-[[LZ-6-17]]
-==== LZ 6-17: Bedeutung von Cost Management für GenAI Applikationen verstehen
+[[LZ-6-11]]
+==== LZ 6-11: Bedeutung von Cost Management für GenAI Applikationen verstehen
 
 Die Teilnehmer:innen verstehen die Bedeutung von Cost Management für GenAI Applikationen.
 
-[[LZ-6-18]]
-==== LZ 6-18: Klassen von Bibliotheken, Schnittstellen und Werkzeugen für LLM-Anwendungen sowie deren Einsatzkontexte und Auswahlkriterien kennen.
+[[LZ-6-12]]
+==== LZ 6-12: Klassen von Bibliotheken, Schnittstellen und Werkzeugen für LLM-Anwendungen sowie deren Einsatzkontexte und Auswahlkriterien kennen.
 
 Die Teilnehmer:innen kennen einige Beispiele von verbreiteten Bibliotheken, Schnittstellen und Tools im Zusammenhang
 mit LLM-Anwendungen wie beispielsweise OpenAI-API oder LangChain.
 
-[[LZ-6-19]]
-==== LZ 6-19: [OPTIONAL] Agentic-AI-Architekturen, zentrale Architekturkomponenten, Sicherheits- und Governance-Grenzen sowie typische Einsatzmuster und Grenzen von Agentensystemen kennen und bewerten.
+[[LZ-6-13]]
+==== LZ 6-13: [OPTIONAL] Agentic-AI-Architekturen, zentrale Architekturkomponenten, Sicherheits- und Governance-Grenzen sowie typische Einsatzmuster und Grenzen von Agentensystemen kennen und bewerten.
 
 Die Teilnehmer:innen kennen Agentic AI Software Architekturen, AI Agent Architekturkomponenten, Typen von AI Agentarchitekturen.
 
-[[LZ 6-20]]
-==== LZ 6-20: Agenten-Laufzeitsysteme für LLM- und Agentensysteme architektonisch einordnen und anwenden
+[[LZ-6-14]]
+==== LZ 6-14: Agenten-Laufzeitsysteme für LLM- und Agentensysteme architektonisch einordnen und anwenden
 
 Die Teilnehmer:innen verstehen Agenten-Laufzeitsysteme als architektonische Kontroll- und Integrationsschicht für probabilistische KI-Komponenten wie LLMs und Agenten. Sie können Harness-Ansätze mit klassischen Architekturkonzepten wie Kapselung, Schnittstellenkontrolle, Invarianten, Betriebsgrenzen, Observability, Policy Enforcement, Fehlerisolierung, kontrollierter Änderung, Governance und Auditierbarkeit beschreiben und beim Entwurf produktionsfähiger KI-Systeme anwenden.
 Sie können insbesondere ableiten, wie ein Agenten-Laufzeitsystem:

--- a/docs/06-module-block-6/02-learning-goals.adoc
+++ b/docs/06-module-block-6/02-learning-goals.adoc
@@ -147,155 +147,143 @@ Sie können insbesondere ableiten, wie ein Agenten-Laufzeitsystem:
 // tag::EN[]
 
 [[LG-6-1]]
-==== LG 6-1: Overview of integration levels of AI
+==== LG 6-1: Gain an overview of AI integration levels
 
 Participants are familiar with the various levels of AI integration. These include the following levels:
 
-- Applications (e.g. coding assistants)
-- AI engineering (e.g. prompt engineering)
-- ML model development (e.g. pytorch)
-- ML infrastructure (e.g. vector DBs).
+* Applications (e.g., coding assistants)
+* AI engineering (e.g., prompt engineering)
+* ML model development (e.g., PyTorch)
+* ML infrastructure (e.g., vector databases)
+
+Participants know some examples of common libraries, interfaces, and tools for integrating AI models.
+
 
 [[LG-6-2]]
-==== LG 6-2: Know libraries, interfaces and tools for the integration of AI models
+==== LG 6-2: Integrate AI systems into the overall architecture of an IT landscape
 
-The participants know some examples of common libraries, interfaces and tools for the integration of AI models.
+Participants know how to integrate AI systems into IT landscapes at a strategic level. For example, they can use strategic design from DDD, particularly context maps, to determine and document the type and degree of integration of AI systems.
 
+[OPTIONAL]
+Using a case study with a fictional business domain, participants practice and discuss how to weigh integration options for AI in an existing software landscape.
 
 [[LG-6-3]]
-==== LG 6-3: Integrate AI systems into the overall architecture of an IT landscape
+==== LG 6-3: Develop a fundamental understanding of generative AI and how it works
 
-Participants know how integrate AI systems into IT landscapes at a strategic level. For example, they can use the strategic design of DDD (especially context maps) to determine and document the type and degree of integration of AI systems.
+Participants have a basic understanding of generative AI, such as LLMs and diffusion models.
+
+Participants understand how LLMs work and can classify the associated terminology: token, embedding, RNN, transformer, attention.
 
 [[LG-6-4]]
-==== LG 6-4: Overview of relevant quality features for AI systems
+==== LG 6-4: Know architecture patterns for using LLMs and evaluate their limitations, risks, and trade-offs, particularly for RAG, function calling, fine-tuning, assistance systems, and agents
 
-The participants understand the quality characteristics that are particularly relevant for AI systems. This includes the following quality characteristics in particular:
+Participants know established patterns for using LLMs. These include the following patterns:
 
-- Reliability
-- Scalability
-- Efficiency
-- Security
-- Maintainability
-- Interpretability
-
+* RAG and retrieval strategies
+* Function calling
+* Fine-tuning
+* Assistants
+* Agents
 
 [[LG-6-5]]
-==== LG 6-5: [OPTIONAL] Know evaluation frameworks for AI systems
+==== LG 6-5: Know and understand use cases for RAG (Retrieval-Augmented Generation) and selected RAG techniques
 
-Participants are familiar with common evaluation frameworks such as LangSmith or LangFuse to deal with indeterminacy and errors in AI systems.
+Participants know typical use cases for RAG, such as “Talk to your documents/database/API.”
+
+In particular, participants know a selection of common RAG techniques, such as:
+
+* Regular RAG, GraphRAG, CAG, agentic RAG, and multi-agent RAG
+* Context enrichment techniques
+* Fusion retrieval
+* Intelligent reranking
+* Query transformations
+* Adaptive retrieval
+* Iterative retrieval
+* Ensemble retrieval
+* Knowledge graph integration
+
 
 [[LG-6-6]]
-==== LG 6-6: [OPTIONAL] Discuss a case study with an imaginary professionalism
+==== LG 6-6: Know types of prompt engineering
 
-Participants will practise and discuss a case study with an imaginary technicality to weigh up integration options for AI into an existing software landscape.
+Participants know different types of prompt engineering, such as:
 
-[[LG-6-7]]
-==== LG 6-7: Fundamental understanding of Generative AI, Language and Diffusion Models, and how they work
-
-The participants have a basic understanding of Generative AI such as LLMs and diffusion models.
-
-[[LG-6-8]]
-==== LG 6-8: Understanding how LLMs work
-
-Participants understand how LLMs work and can categorize the associated terminology: Token, Embedding, RNN, Transformer, Attention.
-
-[[LG-6-9]]
-==== LG 6-9: Understand known patterns in the use of LLMs
-
-The participants understand known patterns for the use of LLMs. This includes the following patterns:
-
-- RAG and retrieval strategies
-- Function calling
-- Finetuning
-- Assistants
-- Agents
-
-[[LG-6-10]]
-==== LG 6-10: Knowing use cases for RAG (Retrieval-Augmented Generation)
-
-The participants know typical use cases for RAG such as "Talk to your documents/database/API".
-
-[[LG-6-11]]
-==== LG 6-11: Knowing and understanding selected RAG techniques
-
-The participants know a selection of common RAG techniques such as:
-
-- Regular RAG, GraphRAG, CAG, Agentic RAG and Multi-Agent RAG
-- Context Enrichment Techniques
-- Fusion Retrieval
-- Intelligent Reranking
-- Query Transformations
-- Adaptive Retrieval
-- Iterative Retrieval
-- Ensemble Retrieval
-- Knowledge Graph Integration
-
-
-[[LG-6-12]]
-==== LG 6-12: Know types of prompt engineering
-
-The participants know different types of prompt engineering, such as
-
-- Few-Shot-Learning
-- Chain-of-Thought
-- Role-Playing
+* Few-shot learning
+* Chain-of-thought
+* Role-playing
 
 as well as general best practices for prompting.
 
 
-[[LG-6-13]]
-==== LG 6-13: Overview of agentic workflows
+[[LG-6-7]]
+==== LG 6-7: Analyze and architecturally classify agentic workflows with regard to planning, tool use, reflection, state management, control mechanisms, and multi-agent collaboration
 
-Participants know what agentic workflows are and are familiar with the terms reflection, tool usage, planning and multi-agent collaboration.
+Participants know what agentic workflows are and are familiar with the concepts of reflection, tool use, planning, and multi-agent collaboration.
+
+[[LG-6-8]]
+==== LG 6-8: Know a selection of design patterns for generative AI systems
+
+Participants know which design patterns exist for generative AI systems. They know a selection of the following patterns:
+
+* AI Query Router (Simple Router; Ranking-based Router; Learning-based Router)
+* Layered Caching Strategy Leading to Fine-Tuning
+* Multiplexing AI Agents
+* Fine-Tuning LLMs for Multiple Tasks
+* Blending Rules-Based and Generative Approaches
+* Utilizing Knowledge Graphs with LLMs
+* Swarm of Generative AI Agents
+* Modular Monolith LLM Approach with Composability
+* Memory Cognition for LLMs
+* Red and Blue Team Dual-Model Evaluation
+
+
+[[LG-6-9]]
+==== LG 6-9: Select techniques for evaluating LLM applications and apply them to response quality, retrieval quality, hallucinations, safety, costs, and user value
+
+Participants know several techniques for evaluating LLM applications. These may include the following techniques, for example:
+
+* Scoring
+* Human feedback
+* Comparative evaluation
+* Model-based evaluation
+
+[OPTIONAL]
+Participants know common evaluation frameworks such as LangSmith or LangFuse for dealing with indeterminacy and errors in AI systems.
+
+[[LG-6-10]]
+==== LG 6-10: Gain an overview of well-known LLMs and selection criteria
+
+Participants are familiar with well-known LLMs such as GPT, Claude, Gemini, Llama, Mistral, or Luminous, and with criteria for selecting a suitable LLM.
+
+[[LG-6-11]]
+==== LG 6-11: Understand the importance of cost management for GenAI applications
+
+Participants understand the importance of cost management for GenAI applications.
+
+[[LG-6-12]]
+==== LG 6-12: Know classes of libraries, interfaces, and tools for LLM applications as well as their application contexts and selection criteria
+
+Participants know some examples of common libraries, interfaces, and tools related to LLM applications, such as the OpenAI API or LangChain.
+
+[[LG-6-13]]
+==== LG 6-13: [OPTIONAL] Know and evaluate agentic AI architectures, key architecture components, security and governance boundaries, and typical usage patterns and limitations of agent systems
+
+Participants know agentic AI software architectures, AI agent architecture components, and types of AI agent architectures.
 
 [[LG-6-14]]
-==== LG 6-14: Know a selection of design patterns for generative AI systems
+==== LG 6-14: Architecturally classify and apply agent runtime systems for LLM and agent systems
 
-The participants know which design patterns exist for generative AI systems. They know a selection of the following patterns:
+Participants understand agent runtime systems as an architectural control and integration layer for probabilistic AI components such as LLMs and agents. They can describe harness approaches using established architecture concepts such as encapsulation, interface control, invariants, operational boundaries, observability, policy enforcement, fault isolation, controlled change, governance, and auditability, and can apply these approaches when designing production-ready AI systems.
 
-- AI Query Router (Simple Router; Ranking-based Router; Learning-based Router)
-- Layered Caching Strategy Leading to Fine-Tuning
-- Multiplexing AI Agents
-- Fine-Tuning LLMs for Multiple Tasks
-- Blending Rules-Based and Generative Approaches
-- Utilizing Knowledge Graphs with LLMs
-- Swarm of Generative AI Agents
-- Modular Monolith LLM Approach with Composability
-- Memory Cognition for LLMs
-- Red and Blue Team Dual-Model Evaluation
+In particular, they can derive how an agent runtime system:
 
-
-[[LG-6-15]]
-==== LG 6-15: Know techniques for evaluating LLM applications
-
-The participants know several techniques for evaluating LLM applications. These can be, for example, the following techniques:
-
-- Scoring
-- Human feedback
-- Comparative Evaluation
-- Model Based Evaluation
-
-
-[[LG-6-16]]
-==== LG 6-16: Overview of known LLMs and selection criteria
-
-The participants are familiar with well-known LLMs such as GPT, Claude, Gemini, Llama, Mistral or Luminous, and the selection criteria for a suitable LLM.
-
-[[LG-6-17]]
-==== LG 6-17: Understanding the importance of cost management for GenAI applications
-
-The participants understand the importance of cost management for GenAI applications.
-
-[[LG-6-18]]
-==== LG 6-18: Give examples of common libraries, interfaces and tools related to LLM applications
-
-The participants know some examples of common libraries, interfaces and tools in connection with LLM applications such as OpenAI-API or LangChain.
-
-[[LG-6-19]]
-==== LG 6-19: [OPTIONAL] Know agentic AI software architectures, AI agent architecture components and types of AI agent architectures
-
-The participants know agentic AI software architectures, AI agent architecture components, types of AI agent architectures.
+* limits the autonomy of an AI component through clear interfaces, permitted actions, and operational boundaries,
+* controls inputs, context, tool access, state, and outputs,
+* enforces system invariants and policies,
+* isolates errors and unsafe model outputs,
+* ensures observability, traceability, and auditability,
+* enables controlled changes to prompts, models, retrieval components, and tools,
+* supports the secure operation and safe evolution of AI systems.
 
 
 

--- a/docs/06-module-block-6/references.adoc
+++ b/docs/06-module-block-6/references.adoc
@@ -1,7 +1,7 @@
 === {references}
 
-<<koc>>, <<dibia>>, <<gradientflow>>, <<bornstein-radovanic>>, <<bahree>>,
-<<spirin>>, <<foster>>, <<parnin>>
+<<bahree>>, <<bornstein-radovanic>>, <<dibia>>, <<foster>>, <<gharbi>>,
+<<gradientflow>>, <<koc>>, <<parnin>>, <<spirin>>
 
 // tag::DE[]
 // end::DE[]

--- a/docs/07-module-block-7/00-structure.adoc
+++ b/docs/07-module-block-7/00-structure.adoc
@@ -15,4 +15,4 @@ include::01-duration-terms.adoc[{include_configuration}]
 include::02-learning-goals.adoc[{include_configuration}]
 
 // references (if any!)
-// include::references.adoc[{include_configuration}]
+include::references.adoc[{include_configuration}]

--- a/docs/07-module-block-7/02-learning-goals.adoc
+++ b/docs/07-module-block-7/02-learning-goals.adoc
@@ -4,7 +4,7 @@
 
 
 [[LZ-7-1]]
-==== LZ 7-1: [OPTIONAL] Anhand von Fallstudien und Praxisprojekten das erworbene Wissen in realen Szenarien anwenden
+==== LZ 7-1: Anhand einer durchgehenden Fallstudie oder eines Praxisprojekts Architekturentscheidungen für ein KI-System treffen, dokumentieren, begründen und im Hinblick auf Qualität, Compliance, Betrieb und Integration bewerten.
 
 // end::DE[]
 

--- a/docs/07-module-block-7/02-learning-goals.adoc
+++ b/docs/07-module-block-7/02-learning-goals.adoc
@@ -11,6 +11,6 @@
 // tag::EN[]
 
 [[LG-7-1]]
-==== LG 7-1: [OPTIONAL] Apply the acquired knowledge in real-life scenarios using case studies and practical projects
+==== LG 7-1: Use an end-to-end case study or practical project to make, document, and justify architectural decisions for an AI system and evaluate them in terms of quality, compliance, operations, and integration.
 
 // end::EN[]

--- a/docs/07-module-block-7/references.adoc
+++ b/docs/07-module-block-7/references.adoc
@@ -1,5 +1,7 @@
 === {references}
 
+<<gharbi>>
+
 // tag::DE[]
 // end::DE[]
 // tag::EN[]

--- a/docs/99-references/00-references.adoc
+++ b/docs/99-references/00-references.adoc
@@ -16,7 +16,6 @@ This section contains references that are cited in the curriculum.
 **A**
 
 - [[[agrawal,Agrawal et al.]]] A. Agrawal, J. Gans, A. Goldfarb:  Prediction Machines: The Simple Economics of Artificial Intelligence https://www.predictionmachines.ai/
-- [[[alake, Alake]]] R. Alake: ML Pipeline Architecture Design Patterns (With 10 Real-World Examples) https://neptune.ai/blog/ml-pipeline-architecture-design-patterns
 - [[[atlas, ATLAS]]] ATLAS - Adversarial Threat Landscape for Artificial-Intelligence Systems. https://github.com/mitre/advmlthreatmatrix
 
 **B**

--- a/docs/99-references/00-references.adoc
+++ b/docs/99-references/00-references.adoc
@@ -44,7 +44,6 @@ This section contains references that are cited in the curriculum.
 
 **E**
 
-- [[[engler,Engler et al.]]] M. Engler, N. Dhamani: Generative AI. Misuse and Adversarial Attacks. https://learning.oreilly.com/library/view/introduction-to-generative/9781633437197/OEBPS/Text/05.html
 - [[[eu-ai-act, EU AI Act]]] EU AI Act https://artificialintelligenceact.eu/de/ai-act-explorer/
 
 **F**

--- a/docs/99-references/00-references.adoc
+++ b/docs/99-references/00-references.adoc
@@ -54,6 +54,7 @@ This section contains references that are cited in the curriculum.
 
 **G**
 
+- [[[gharbi,Gharbi et al. 2026]]] M. Gharbi, H. Klus, H. Tiemeyer, M. Zhang: Praxiswissen Softwarearchitektur für KI-Systeme: Grundlagen, Konzepte, Techniken und Plattformen. Aus- und Weiterbildung zum Certified Professional for Software Architecture – Advanced Level – Modul SWARC4AI nach iSAQB®-Standard. dpunkt.verlag, 2026.
 - [[[geron,Géron 2022]]] Aurélien Géron: Hands-On Machine Learning with Scikit-Learn, Keras, and TensorFlow https://learning.oreilly.com/library/view/hands-on-machine-learning/9781098125967/
 - [[[gradientflow,Gradient Flow]]] LLM Routers Unpacked https://gradientflow.com/llm-routers-unpacked/
 


### PR DESCRIPTION
In this PR the new curriculum learning goals are revised, cleaned up, consolidated and sharpened as aligned with @magnusse and @visenger . All currently available Issues are also resolved.

More details:
* Module 1
  * LG 1-2 and 1-8 consolidated
  * LG 1-4 and 1-9 consolidated
  * LG 1-5 and 1-6 consolidated
* Module 2
  * LG 2-4 and 2-5 consolidated
  * LG 2-8 and 2-10 consolidated
  * LG 2-12, 2-13 and LG 2-14 merged and consolidated with 2-6 and 2-7; AI Principles documents optional
  * LG 2-16 removed and merged with the similar LG 4-4
* Module 3
  * LG 3-1 and 3-2 merged, as they fit well together in terms of content
  * LG 3-3 consolidated with LG 3-4 and LG 3-5
  * LG 3-6 can be omitted, as the LG is not specific enough; LG 5-8 is redundant—the topic fits better in Chapter 5 -> LG 3-6 removed
  * LG 3-7 and 3-8 consolidated
  * LG 3-9 consolidated with the new LG 3-23, as they fit well together in terms of content
  * LG 3-10 removed, as it is redundant with the new LG 3-3
  * LG 3-14 and 3-15 consolidated
  * LG 3-19 removed, as it is redundant and already covered in Chapter 2
  * LG 3-21 removed and combined with the similar LG 2-11; bias fits better under AI Safety, Ethics, Risk, and Data Governance in Module 2 than under Design/Development in Module 3
* Module 4
  * LG 4-3 consolidated with 4-1 and remains optional
  * LG 4-6 consolidated with 4-4 and marked as optional
  * LG 4-7 remains and has been expanded to include vector databases and graph databases; these are generally interesting and architecturally relevant for participants (RAG). The remaining storage technologies are retained only for completeness
* Module 5
  * LG 5-1 remains and has been expanded to include NPUs and LPUs, as new AI accelerators are generally very interesting for participants and offer significant potential for runtime cost and efficiency improvements
  * LG 3-5 and 5-20 consolidated
  * LG 5-10 and 5-11 consolidated and marked as [OPTIONAL]; then consolidated with 5-9 and 5-12
  * LG 5-13, 5-14 and 5-21 consolidated
  * LG 5-15 removed, as it is redundant with 3-8
  * LG 5-16 and 5-17 merged
  * LG 5-19 marked as [OPTIONAL] and consolidated with 5-18; generally interesting for participants in the context of systematic, iterative ML optimization, but not among the most central topics
* Module 6
  * LG 6-1 and 6-2 consolidated
  * LG 6-3 and 6-6 consolidated
  * LG 6-4 removed, as it is redundant and quality attributes can be covered in Module 5
  * LG 6-5 and 6-15 consolidated
  * LG 6-7 and LG 6-8 consolidated
  * LG 6-11 remains and consolidated with 6-10, as there are many specific use cases / benefits / trade-offs associated with it, and it has been slightly corrected and expanded to include GraphRAG, CAG, Agentic RAG, and Multi-Agent RAG -> highly requested in the training sessions, including understanding the differences and trade-offs
  * LG 6-14 remains unchanged for now, as it covers fundamental LLM-specific design patterns
  * LG 6-20: Harness renamed to agent runtime system
* General:
  * Renumbered all learning goals and updated / synchronized the English translation, which fixed #42 and #34 
  * Removed references and resolved #35 and #54 as the new references cover the content in more detail
  * Cleanup and sorting of all references